### PR TITLE
Added PositiveSemiDefiniteStructure

### DIFF
--- a/src/NeuralLyapunov.jl
+++ b/src/NeuralLyapunov.jl
@@ -16,6 +16,7 @@ export NeuralLyapunovPDESystem, NumericalNeuralLyapunovFunctions
 export local_Lyapunov
 export NeuralLyapunovSpecification, NeuralLyapunovStructure, 
     UnstructuredNeuralLyapunov, NonnegativeNeuralLyapunov, 
+    PositiveSemiDefiniteStructure,
     LyapunovMinimizationCondition, StrictlyPositiveDefinite, 
     PositiveSemiDefinite, DontCheckNonnegativity, LyapunovDecreaseCondition,
     AsymptoticDecrease, ExponentialDecrease, DontCheckDecrease

--- a/src/NeuralLyapunovPDESystem.jl
+++ b/src/NeuralLyapunovPDESystem.jl
@@ -119,6 +119,15 @@ function NeuralLyapunovPDESystem(
     if isempty(eqs) && isempty(bcs)
         error("No training conditions specified.")
     end
+    
+    # NeuralPDE requires an equation and a boundary condition, even if they are
+    # trivial like 0.0 == 0.0
+    if isempty(eqs)
+        push!(eqs, 0.0 ~ 0.0)
+    end
+    if isempty(bcs)
+        push!(bcs, 0.0 ~ 0.0)
+    end
 
     ########################### Construct PDESystem ###########################
     @named lyapunov_pde_system = PDESystem(

--- a/src/conditions_specification.jl
+++ b/src/conditions_specification.jl
@@ -121,13 +121,15 @@ function PositiveSemiDefiniteStructure(
         grad_non_neg = nothing,
         grad = ForwardDiff.gradient,
     )
+    _grad(f::Function, x::AbstractArray{T}) where T<:Num = Symbolics.gradient(f(x), x)
+    _grad(f::Function, x) = grad(f, x)
     grad_pos_def = if isnothing(grad_pos_def)
-        (state, fixed_point) -> grad((x) -> pos_def(x, fixed_point), state)
+        (state, fixed_point) -> _grad((x) -> pos_def(x, fixed_point), state)
     else
         grad_pos_def
     end
     grad_non_neg = if isnothing(grad_non_neg)
-        (net, J_net, state, fixed_point) -> grad((x) -> non_neg(net, x, fixed_point), state)
+        (net, J_net, state, fixed_point) -> _grad((x) -> non_neg(net, x, fixed_point), state)
     else
         grad_non_neg
     end

--- a/src/conditions_specification.jl
+++ b/src/conditions_specification.jl
@@ -90,6 +90,59 @@ function NonnegativeNeuralLyapunov(
     end
 end
 
+"""
+    PositiveSemiDefiniteStructure(network_dim; pos_def, non_neg, grad_pos_def, grad_non_neg, grad)
+
+Creates a NeuralLyapunovStructure where the Lyapunov function is the product of
+a positive (semi-)definite function pos_def which does not depend on the 
+network and a nonnegative function non_neg which does depend the network.
+
+The condition that the Lyapunov function must be minimized uniquely at the
+fixed point can be represented as V(fixed_point) = 0, V(state) > 0 when 
+state != fixed_point. This structure ensures V(state) ≥ 0. Further, if pos_def
+is 0 only at fixed_point (and positive elsewhere) and if non_neg is strictly 
+positive away from fixed_point (as is the case for the default values of pos_def
+and non_neg), then this structure ensures V(fixed_point) = 0 and V(state) > 0 
+when state != fixed_point.
+
+grad_pos_def(state, fixed_point) should be the gradient of pos_def with respect
+to state at state. Similarly, grad_non_neg(net, J_net, state, fixed_point) 
+should be the gradient of non_neg(net, state, fixed_point) with respect to 
+state at state. If grad_pos_def or grad_non_neg is not defined, it is evaluated 
+using grad, which defaults to ForwardDiff.gradient. 
+
+The neural network output has dimension network_dim.
+"""
+function PositiveSemiDefiniteStructure(
+        network_dim::Integer;
+        pos_def::Function = (state, fixed_point) -> log(1.0 + (state - fixed_point) ⋅ (state - fixed_point)),
+        non_neg::Function = (net, state, fixed_point) -> 1 + net(state) ⋅ net(state),
+        grad_pos_def = nothing,
+        grad_non_neg = nothing,
+        grad = ForwardDiff.gradient,
+    )
+    grad_pos_def = if isnothing(grad_pos_def)
+        (state, fixed_point) -> grad((x) -> pos_def(x, fixed_point), state)
+    else
+        grad_pos_def
+    end
+    grad_non_neg = if isnothing(grad_non_neg)
+        (net, J_net, state, fixed_point) -> grad((x) -> non_neg(net, x, fixed_point), state)
+    else
+        grad_non_neg
+    end
+    NeuralLyapunovStructure(
+        (net, state, fixed_point) -> pos_def(state, fixed_point) * non_neg(net, state, fixed_point),
+        (net, J_net, state, fixed_point) -> 
+            grad_pos_def(state, fixed_point) * non_neg(net, state, fixed_point) + 
+            pos_def(state, fixed_point) * grad_non_neg(net, J_net, state, fixed_point),
+        (net, J_net, f, state, fixed_point) -> 
+            (f(state) ⋅ grad_pos_def(state, fixed_point)) * non_neg(net, state, fixed_point) + 
+            pos_def(state, fixed_point) * (f(state) ⋅ grad_non_neg(net, J_net, state, fixed_point)),
+        network_dim
+    )
+end
+
 abstract type AbstractLyapunovMinimizationCondition end
 
 """


### PR DESCRIPTION
Added Lyapunov function structure to the library: `PositiveSemiDefiniteStructure`, which implements a multiplicative structure that can be used to enforce positive semi-definiteness of the Lyapunov function.

By structuring $V(x) = p(x) g(\phi, x)$ with $p(x), g(\phi, x) \ge 0 \forall \phi,x$ and $p(x_{eq})=0$, we have a guarantee that $V$ is nonnegative away from equilibrium and zero at equilibrium (positive semi-definite), regardless of the choice of network $\phi$.

One example of a simple $p$ and $g$ is $p(x) = | x - x_{eq} |^2$ and $g(\phi, x) = | \phi(x) |^2$.

Additionally, by making the inequalities strict (as the example $p$ satisfies and the example $g$ could be made to satisfy by adding a term like $p$), $V$ is guaranteed to be positive away from equilibrium (positive definite).

This structure compares with the `NonnegativeNeuralLyapunov` in that it is multiplicative instead of additive and therefore allows us to enforce $V(x_{eq}) = 0$ structurally.