### PR TITLE
Renaming decrease conditions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,6 +24,8 @@ SciMLBase = "2"
 julia = "1.10"
 
 [extras]
+Boltz = "4544d5e4-abc5-4dea-817f-29e4c205d9c8"
+CSDP = "0a46da34-8e4b-519e-b418-48813639ff34"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
 NLopt = "76087f3c-5699-56af-9a33-bf431cd00edd"
@@ -34,7 +36,6 @@ OptimizationOptimisers = "42dfb2eb-d2b4-4451-abcd-913932933ac1"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-CSDP = "0a46da34-8e4b-519e-b418-48813639ff34"
 
 [targets]
-test = ["SafeTestsets", "Test", "Lux", "Optimization", "OptimizationOptimJL", "OptimizationOptimisers", "NLopt", "Random", "NeuralPDE", "DifferentialEquations", "CSDP"]
+test = ["SafeTestsets", "Test", "Lux", "Optimization", "OptimizationOptimJL", "OptimizationOptimisers", "NLopt", "Random", "NeuralPDE", "DifferentialEquations", "CSDP", "Boltz"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Boltz = "4544d5e4-abc5-4dea-817f-29e4c205d9c8"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Lux = "b2108857-7c20-44ae-9111-449ecde12c47"

--- a/docs/src/demos/damped_SHO.md
+++ b/docs/src/demos/damped_SHO.md
@@ -259,7 +259,7 @@ println(
 )
 ```
 
-At least at these validation samples, the conditions that ``\dot{V}`` be negative semi-definite and ``V`` be minimized at the origin are nearly sastisfied.
+At least at these validation samples, the conditions that ``\dot{V}`` be negative semi-definite and ``V`` be minimized at the origin are nearly satisfied.
 
 ```@example SHO
 using Plots

--- a/docs/src/demos/damped_SHO.md
+++ b/docs/src/demos/damped_SHO.md
@@ -61,8 +61,8 @@ structure = NonnegativeNeuralLyapunov(
 minimization_condition = DontCheckNonnegativity(check_fixed_point = true)
 
 # Define Lyapunov decrease condition
-# Damped SHO has exponential decrease at a rate of k = ζ * ω_0, so we train to certify that
-decrease_condition = ExponentialDecrease(prod(p))
+# Damped SHO has exponential stability at a rate of k = ζ * ω_0, so we train to certify that
+decrease_condition = ExponentialStability(prod(p))
 
 # Construct neural Lyapunov specification
 spec = NeuralLyapunovSpecification(
@@ -165,7 +165,7 @@ which structurally enforces nonnegativity, but doesn't guarantee ``V([0, 0]) = 0
 We therefore don't need a term in the loss function enforcing ``V(x) > 0 \, \forall x \ne 0``, but we do need something enforcing ``V([0, 0]) = 0``.
 So, we use [`DontCheckNonnegativity(check_fixed_point = true)`](@ref).
 
-To train for exponential decrease we use [`ExponentialDecrease`](@ref), but we must specify the rate of exponential decrease, which we know in this case to be ``\zeta \omega_0``.
+To train for exponential stability we use [`ExponentialStability`](@ref), but we must specify the rate of exponential decrease, which we know in this case to be ``\zeta \omega_0``.
 
 ```@example SHO
 using NeuralLyapunov
@@ -178,8 +178,8 @@ structure = NonnegativeNeuralLyapunov(
 minimization_condition = DontCheckNonnegativity(check_fixed_point = true)
 
 # Define Lyapunov decrease condition
-# Damped SHO has exponential decrease at a rate of k = ζ * ω_0, so we train to certify that
-decrease_condition = ExponentialDecrease(prod(p))
+# Damped SHO has exponential stability at a rate of k = ζ * ω_0, so we train to certify that
+decrease_condition = ExponentialStability(prod(p))
 
 # Construct neural Lyapunov specification
 spec = NeuralLyapunovSpecification(

--- a/docs/src/demos/damped_SHO.md
+++ b/docs/src/demos/damped_SHO.md
@@ -88,8 +88,6 @@ prob = discretize(pde_system, discretization)
 ########################## Solve OptimizationProblem ##########################
 
 res = Optimization.solve(prob, OptimizationOptimisers.Adam(); maxiters = 500)
-prob = Optimization.remake(prob, u0 = res.u)
-res = Optimization.solve(prob, OptimizationOptimJL.BFGS(); maxiters = 500)
 
 ###################### Get numerical numerical functions ######################
 net = discretization.phi
@@ -206,8 +204,6 @@ prob = discretize(pde_system, discretization)
 using Optimization, OptimizationOptimisers, OptimizationOptimJL
 
 res = Optimization.solve(prob, OptimizationOptimisers.Adam(); maxiters = 500)
-prob = Optimization.remake(prob, u0 = res.u)
-res = Optimization.solve(prob, OptimizationOptimJL.BFGS(); maxiters = 500)
 
 net = discretization.phi
 θ = res.u.depvar

--- a/docs/src/demos/policy_search.md
+++ b/docs/src/demos/policy_search.md
@@ -13,7 +13,7 @@ We'll jointly train a neural controller ``\tau = u \left( \theta, \frac{d\theta}
 ## Copy-Pastable Code
 
 ```julia
-using NeuralPDE, Lux, ModelingToolkit, NeuralLyapunov
+using NeuralPDE, Lux, Boltz, ModelingToolkit, NeuralLyapunov
 import Optimization, OptimizationOptimisers, OptimizationOptimJL
 using Random
 
@@ -55,7 +55,7 @@ dim_phi = 3
 dim_u = 1
 dim_output = dim_phi + dim_u
 chain = [Lux.Chain(
-             PeriodicEmbedding([1], [2π]),
+             Boltz.Layers.PeriodicEmbedding([1], [2π]),
              Dense(3, dim_hidden, tanh),
              Dense(dim_hidden, dim_hidden, tanh),
              Dense(dim_hidden, 1)
@@ -179,7 +179,7 @@ Other than that, setting up the neural network using Lux and NeuralPDE training 
 For more on that aspect, see the [NeuralPDE documentation](https://docs.sciml.ai/NeuralPDE/stable/).
 
 ```@example policy_search
-using Lux
+using Lux, Boltz
 
 # Define neural network discretization
 # We use an input layer that is periodic with period 2π with respect to θ
@@ -189,7 +189,7 @@ dim_phi = 3
 dim_u = 1
 dim_output = dim_phi + dim_u
 chain = [Lux.Chain(
-             PeriodicEmbedding([1], [2π]),
+             Boltz.Layers.PeriodicEmbedding([1], [2π]),
              Dense(3, dim_hidden, tanh),
              Dense(dim_hidden, dim_hidden, tanh),
              Dense(dim_hidden, 1)
@@ -384,7 +384,7 @@ Now, let's simulate the closed-loop dynamics to verify that the controller can g
 First, we'll start at the downward equilibrium:
 
 ```@example policy_search
-state_order = map(st -> SymbolicUtils.iscall(st) ? operation(st) : st, state_order)
+state_order = map(st -> SymbolicUtils.isterm(st) ? operation(st) : st, state_order)
 state_syms = Symbol.(state_order)
 
 closed_loop_dynamics = ODEFunction(

--- a/docs/src/demos/policy_search.md
+++ b/docs/src/demos/policy_search.md
@@ -81,7 +81,7 @@ structure = add_policy_search(
 minimization_condition = DontCheckNonnegativity(check_fixed_point = false)
 
 # Define Lyapunov decrease condition
-decrease_condition = AsymptoticDecrease(strict = true)
+decrease_condition = AsymptoticStability()
 
 # Construct neural Lyapunov specification
 spec = NeuralLyapunovSpecification(
@@ -243,7 +243,7 @@ Since our Lyapunov candidate structurally enforces positive definiteness, we use
 minimization_condition = DontCheckNonnegativity(check_fixed_point = false)
 
 # Define Lyapunov decrease condition
-decrease_condition = AsymptoticDecrease(strict = true)
+decrease_condition = AsymptoticStability()
 
 # Construct neural Lyapunov specification
 spec = NeuralLyapunovSpecification(

--- a/docs/src/demos/roa_estimation.md
+++ b/docs/src/demos/roa_estimation.md
@@ -47,7 +47,7 @@ structure = PositiveSemiDefiniteStructure(dim_output)
 minimization_condition = DontCheckNonnegativity()
 
 # Define Lyapunov decrease condition
-decrease_condition = make_RoA_aware(AsymptoticDecrease(strict = true))
+decrease_condition = make_RoA_aware(AsymptoticStability())
 
 # Construct neural Lyapunov specification
 spec = NeuralLyapunovSpecification(
@@ -151,7 +151,7 @@ V(x) = \left( 1 + \lVert \phi(x) \rVert^2 \right) \log \left( 1 + \lVert x \rVer
 which structurally enforces positive definiteness.
 We therefore use [`DontCheckNonnegativity()`](@ref).
 
-We only require asymptotic decrease in this example, but we use [`make_RoA_aware`](@ref) to only penalize positive values of ``\dot{V}(x)`` when ``V(x) \le 1``.
+We only require asymptotic stability in this example, but we use [`make_RoA_aware`](@ref) to only penalize positive values of ``\dot{V}(x)`` when ``V(x) \le 1``.
 
 ```@example RoA
 using NeuralLyapunov
@@ -161,7 +161,7 @@ structure = PositiveSemiDefiniteStructure(dim_output)
 minimization_condition = DontCheckNonnegativity()
 
 # Define Lyapunov decrease condition
-decrease_condition = make_RoA_aware(AsymptoticDecrease(strict = true))
+decrease_condition = make_RoA_aware(AsymptoticStability())
 
 # Construct neural Lyapunov specification
 spec = NeuralLyapunovSpecification(

--- a/docs/src/man/decrease.md
+++ b/docs/src/man/decrease.md
@@ -21,8 +21,9 @@ LyapunovDecreaseCondition
 ## Pre-defined decrease conditions
 
 ```@docs
-AsymptoticDecrease
-ExponentialDecrease
+AsymptoticStability
+ExponentialStability
+StabilityISL
 DontCheckDecrease
 ```
 

--- a/docs/src/man/policy_search.md
+++ b/docs/src/man/policy_search.md
@@ -1,4 +1,4 @@
-# Policy Search and Network-Sependent Dynamics
+# Policy Search and Network-Dependent Dynamics
 
 At times, we wish to model a component of the dynamics with a neural network.
 A common example is the policy search case, when the closed-loop dynamics include a neural network controller.

--- a/src/NeuralLyapunov.jl
+++ b/src/NeuralLyapunov.jl
@@ -25,7 +25,8 @@ export LyapunovMinimizationCondition, StrictlyPositiveDefinite, PositiveSemiDefi
        DontCheckNonnegativity
 
 # Decrease conditions
-export LyapunovDecreaseCondition, AsymptoticDecrease, ExponentialDecrease, DontCheckDecrease
+export LyapunovDecreaseCondition, StabilityISL, AsymptoticStability, ExponentialStability,
+       DontCheckDecrease
 
 # Setting up the PDESystem for NeuralPDE
 export NeuralLyapunovSpecification, NeuralLyapunovPDESystem

--- a/src/NeuralLyapunovPDESystem.jl
+++ b/src/NeuralLyapunovPDESystem.jl
@@ -215,11 +215,11 @@ function _NeuralLyapunovPDESystem(
     # φ(x) is the symbolic form of neural network output
     φ(x) = Num.([φi(x...) for φi in net])
 
-    # V_sym(x) is the symobolic form of the Lyapunov function
-    V_sym(x) = structure.V(φ, x, fixed_point)
+    # V(x) is the symobolic form of the Lyapunov function
+    V(x) = structure.V(φ, x, fixed_point)
 
-    # V̇_sym(x) is the symbolic time derivative of the Lyapunov function
-    function V̇_sym(x)
+    # V̇(x) is the symbolic time derivative of the Lyapunov function
+    function V̇(x)
         structure.V̇(
             φ,
             y -> Symbolics.jacobian(φ(y), y),
@@ -236,18 +236,18 @@ function _NeuralLyapunovPDESystem(
 
     if check_nonnegativity(minimzation_condition)
         cond = get_minimization_condition(minimzation_condition)
-        push!(eqs, cond(V_sym, state, fixed_point) ~ 0.0)
+        push!(eqs, cond(V, state, fixed_point) ~ 0.0)
     end
 
     if check_decrease(decrease_condition)
         cond = get_decrease_condition(decrease_condition)
-        push!(eqs, cond(V_sym, V̇_sym, state, fixed_point) ~ 0.0)
+        push!(eqs, cond(V, V̇, state, fixed_point) ~ 0.0)
     end
 
     bcs = []
 
     if check_minimal_fixed_point(minimzation_condition)
-        push!(bcs, V_sym(fixed_point) ~ 0.0)
+        push!(bcs, V(fixed_point) ~ 0.0)
     end
 
     if policy_search

--- a/src/NeuralLyapunovPDESystem.jl
+++ b/src/NeuralLyapunovPDESystem.jl
@@ -202,7 +202,7 @@ function _NeuralLyapunovPDESystem(
 )::PDESystem
     ########################## Unpack specifications ##########################
     structure = spec.structure
-    minimzation_condition = spec.minimzation_condition
+    minimization_condition = spec.minimization_condition
     decrease_condition = spec.decrease_condition
     f_call = structure.f_call
     state_dim = length(domains)
@@ -234,8 +234,8 @@ function _NeuralLyapunovPDESystem(
     ################ Define equations and boundary conditions #################
     eqs = []
 
-    if check_nonnegativity(minimzation_condition)
-        cond = get_minimization_condition(minimzation_condition)
+    if check_nonnegativity(minimization_condition)
+        cond = get_minimization_condition(minimization_condition)
         push!(eqs, cond(V, state, fixed_point) ~ 0.0)
     end
 
@@ -246,7 +246,7 @@ function _NeuralLyapunovPDESystem(
 
     bcs = []
 
-    if check_minimal_fixed_point(minimzation_condition)
+    if check_minimal_fixed_point(minimization_condition)
         push!(bcs, V(fixed_point) ~ 0.0)
     end
 

--- a/src/NeuralLyapunovPDESystem.jl
+++ b/src/NeuralLyapunovPDESystem.jl
@@ -121,7 +121,7 @@ function NeuralLyapunovPDESystem(
         p_syms = if isnothing(dynamics.sys.parameters)
             []
         else
-            dynamics.sys.parameters
+            keys(dynamics.sys.parameters)
         end
         (s_syms, p_syms)
     else

--- a/src/conditions_specification.jl
+++ b/src/conditions_specification.jl
@@ -11,8 +11,8 @@ structurally enforcing some Lyapunov conditions.
     `state`.
   - `V̇(phi::Function, J_phi::Function, dynamics::Function, state, params, t, fixed_point)`:
     outputs the time derivative of the Lyapunov function at `state`.
-  - `f_call(dynamics::Function, phi::Function, state, p, t)`: outputs the derivative of the
-    state; this is useful for making closed-loop dynamics which depend on the neural
+  - `f_call(dynamics::Function, phi::Function, state, params, t)`: outputs the derivative of
+    the state; this is useful for making closed-loop dynamics which depend on the neural
     network, such as in the policy search case.
   - `network_dim`: the dimension of the output of the neural network.
 
@@ -97,8 +97,8 @@ Note that the first input, ``V``, is a function, so the minimization condition c
 the value of the candidate Lyapunov function at multiple points.
 """
 function get_minimization_condition(cond::AbstractLyapunovMinimizationCondition)
-    error("get_condition not implemented for AbstractLyapunovMinimizationCondition of " *
-          "type $(typeof(cond))")
+    error("get_minimization_condition not implemented for " *
+          "AbstractLyapunovMinimizationCondition of type $(typeof(cond))")
 end
 
 """
@@ -122,6 +122,6 @@ Note that the first two inputs, ``V`` and ``V̇``, are functions, so the decreas
 can depend on the value of these functions at multiple points.
 """
 function get_decrease_condition(cond::AbstractLyapunovDecreaseCondition)
-    error("get_condition not implemented for AbstractLyapunovDecreaseCondition of type " *
-          string((typeof(cond))))
+    error("get_decrease_condition not implemented for AbstractLyapunovDecreaseCondition " *
+          "of type $(typeof(cond))")
 end

--- a/src/conditions_specification.jl
+++ b/src/conditions_specification.jl
@@ -60,7 +60,7 @@ Specifies a neural Lyapunov problem.
 """
 struct NeuralLyapunovSpecification
     structure::NeuralLyapunovStructure
-    minimzation_condition::AbstractLyapunovMinimizationCondition
+    minimization_condition::AbstractLyapunovMinimizationCondition
     decrease_condition::AbstractLyapunovDecreaseCondition
 end
 

--- a/src/decrease_conditions.jl
+++ b/src/decrease_conditions.jl
@@ -81,13 +81,14 @@ end
 
 Construct a [`LyapunovDecreaseCondition`](@ref) corresponding to asymptotic decrease.
 
-If `strict == false`, the decrease condition is
-``\\dot{V}(x) ≤ 0``,
-and if `strict == true`, the condition is
-``\\dot{V}(x) ≤ - C \\lVert x - x_0 \\rVert^2``.
+If `strict == false` (as is the default), the decrease condition is ``\\dot{V}(x) ≤ 0``,
+and if `strict == true`, the condition is ``\\dot{V}(x) ≤ - C \\lVert x - x_0 \\rVert^2``.
+``C`` defaults to `1e-6`.
 
 The inequality is represented by
 ``\\texttt{rectifier}(\\dot{V}(x) + C \\lVert x - x_0 \\rVert^2) = 0``.
+The default value `rectifier = (t) -> max(zero(t), t)` exactly represents the inequality,
+but differentiable approximations of this function may be employed.
 """
 function AsymptoticDecrease(;
         strict::Bool = false,
@@ -114,11 +115,14 @@ end
 Construct a [`LyapunovDecreaseCondition`](@ref) corresponding to exponential decrease of
 rate ``k``.
 
-If `strict == false`, the condition is ``\\dot{V}(x) ≤ -k V(x)``, and if `strict == true`,
+If `strict == false` (as is the default), the condition is ``\\dot{V}(x) ≤ -k V(x)``, and if `strict == true`,
 the condition is ``\\dot{V}(x) ≤ -k V(x) - C \\lVert x - x_0 \\rVert^2``.
+``C`` defaults to `1e-6`.
 
 The inequality is represented by
 ``\\texttt{rectifier}(\\dot{V}(x) + k V(x) + C \\lVert x - x_0 \\rVert^2) = 0``.
+The default value `rectifier = (t) -> max(zero(t), t)` exactly represents the inequality,
+but differentiable approximations of this function may be employed.
 """
 function ExponentialDecrease(
         k::Real;

--- a/src/decrease_conditions.jl
+++ b/src/decrease_conditions.jl
@@ -40,7 +40,7 @@ for some positive ``C``, which corresponds to
     rate_metric = (V, dVdt) -> dVdt
     strength = (x, x0) -> C * (x - x0) ⋅ (x - x0)
 
-This can also be accomplished with [`AsymptoticDecrease`](@ref).
+This can also be accomplished with [`AsymptoticStability`](@ref).
 
 Exponential decrease of rate ``k`` is proven by
     ``V̇(x) ≤ - k V(x)``,
@@ -49,7 +49,7 @@ which corresponds to
     rate_metric = (V, dVdt) -> dVdt + k * V
     strength = (x, x0) -> 0.0
 
-This can also be accomplished with [`ExponentialDecrease`](@ref).
+This can also be accomplished with [`ExponentialStability`](@ref).
 
 In either case, the rectified linear unit `rectifier = (t) -> max(zero(t), t)` exactly
 represents the inequality, but differentiable approximations of this function may be
@@ -77,69 +77,70 @@ function get_decrease_condition(cond::LyapunovDecreaseCondition)
 end
 
 """
-    AsymptoticDecrease(; strict, C, rectifier)
+    StabilityISL(; rectifier)
 
-Construct a [`LyapunovDecreaseCondition`](@ref) corresponding to asymptotic decrease.
+Construct a [`LyapunovDecreaseCondition`](@ref) corresponding to stability in the sense of
+Lyapunov (i.s.L.).
 
-If `strict == false` (as is the default), the decrease condition is ``\\dot{V}(x) ≤ 0``,
-and if `strict == true`, the condition is ``\\dot{V}(x) ≤ - C \\lVert x - x_0 \\rVert^2``.
-``C`` defaults to `1e-6`.
-
-The inequality is represented by
-``\\texttt{rectifier}(\\dot{V}(x) + C \\lVert x - x_0 \\rVert^2) = 0``.
-The default value `rectifier = (t) -> max(zero(t), t)` exactly represents the inequality,
-but differentiable approximations of this function may be employed.
+Stability i.s.L. is proven by ``V̇(x) ≤ 0``. The inequality is represented by
+``\\texttt{rectifier}(V̇(x)) = 0``. The default value `rectifier = (t) -> max(zero(t), t)`
+exactly represents the inequality, but differentiable approximations of this function may be
+employed.
 """
-function AsymptoticDecrease(;
-        strict::Bool = false,
-        C::Real = 1e-6,
-        rectifier = (t) -> max(zero(t), t)
-)::LyapunovDecreaseCondition
-    strength = if strict
-        (x, x0) -> C * (x - x0) ⋅ (x - x0)
-    else
-        (x, x0) -> 0.0
-    end
-
+function StabilityISL(; rectifier = (t) -> max(zero(t), t))
     return LyapunovDecreaseCondition(
         true,
         (V, dVdt) -> dVdt,
-        strength,
+        (x, x0) -> 0.0,
         rectifier
     )
 end
 
 """
-    ExponentialDecrease(k; strict, C, rectifier)
+    AsymptoticStability(; C, rectifier)
 
-Construct a [`LyapunovDecreaseCondition`](@ref) corresponding to exponential decrease of
-rate ``k``.
+Construct a [`LyapunovDecreaseCondition`](@ref) corresponding to asymptotic stability.
 
-If `strict == false` (as is the default), the condition is ``\\dot{V}(x) ≤ -k V(x)``, and if `strict == true`,
-the condition is ``\\dot{V}(x) ≤ -k V(x) - C \\lVert x - x_0 \\rVert^2``.
-``C`` defaults to `1e-6`.
+The decrease condition for asymptotic stability is ``V̇(x) < 0``, which is here represented
+as ``V̇(x) ≤ - C \\lVert x - x_0 \\rVert^2`` for some ``C > 0``. ``C`` defaults to `1e-6`.
 
 The inequality is represented by
-``\\texttt{rectifier}(\\dot{V}(x) + k V(x) + C \\lVert x - x_0 \\rVert^2) = 0``.
+``\\texttt{rectifier}(V̇(x) + C \\lVert x - x_0 \\rVert^2) = 0``.
 The default value `rectifier = (t) -> max(zero(t), t)` exactly represents the inequality,
 but differentiable approximations of this function may be employed.
 """
-function ExponentialDecrease(
-        k::Real;
-        strict::Bool = false,
+function AsymptoticStability(;
         C::Real = 1e-6,
         rectifier = (t) -> max(zero(t), t)
 )::LyapunovDecreaseCondition
-    strength = if strict
-        (x, x0) -> C * (x - x0) ⋅ (x - x0)
-    else
-        (x, x0) -> 0.0
-    end
+    return LyapunovDecreaseCondition(
+        true,
+        (V, dVdt) -> dVdt,
+        (x, x0) -> C * (x - x0) ⋅ (x - x0),
+        rectifier
+    )
+end
 
+"""
+    ExponentialStability(k; rectifier)
+
+Construct a [`LyapunovDecreaseCondition`](@ref) corresponding to exponential stability of
+rate ``k``.
+
+The Lyapunov condition for exponential stability is ``V̇(x) ≤ -k V(x)`` for some ``k > 0``.
+
+The inequality is represented by ``\\texttt{rectifier}(V̇(x) + k V(x)) = 0``.
+The default value `rectifier = (t) -> max(zero(t), t)` exactly represents the inequality,
+but differentiable approximations of this function may be employed.
+"""
+function ExponentialStability(
+        k::Real;
+        rectifier = (t) -> max(zero(t), t)
+)::LyapunovDecreaseCondition
     return LyapunovDecreaseCondition(
         true,
         (V, dVdt) -> dVdt + k * V,
-        strength,
+        (x, x0) -> 0.0,
         rectifier
     )
 end

--- a/src/decrease_conditions_RoA_aware.jl
+++ b/src/decrease_conditions_RoA_aware.jl
@@ -127,8 +127,9 @@ by `cond` only in that sublevel set.
 
 # Arguments
   - `cond::LyapunovDecreaseCondition`: specifies the loss to be applied when ``V(x) ≤ ρ``.
-  - `ρ`: the target level such that the RoA will be ``\\{ x : V(x) ≤ ρ \\}``.
-  - `out_of_RoA_penalty::Function`: specifies the loss to be applied when ``V(x) > ρ``.
+  - `ρ`: the target level such that the RoA will be ``\\{ x : V(x) ≤ ρ \\}``, defaults to 1.
+  - `out_of_RoA_penalty::Function`: specifies the loss to be applied when ``V(x) > ρ``,
+    defaults to no loss.
   - `sigmoid::Function`: approximately one when the input is positive and approximately zero
     when the input is negative.
 

--- a/src/decrease_conditions_RoA_aware.jl
+++ b/src/decrease_conditions_RoA_aware.jl
@@ -127,11 +127,13 @@ by `cond` only in that sublevel set.
 
 # Arguments
   - `cond::LyapunovDecreaseCondition`: specifies the loss to be applied when ``V(x) ≤ ρ``.
+
+# Keyword Arguments
   - `ρ`: the target level such that the RoA will be ``\\{ x : V(x) ≤ ρ \\}``, defaults to 1.
   - `out_of_RoA_penalty::Function`: specifies the loss to be applied when ``V(x) > ρ``,
     defaults to no loss.
   - `sigmoid::Function`: approximately one when the input is positive and approximately zero
-    when the input is negative.
+    when the input is negative, defaults to unit step function.
 
 The loss applied to samples ``x`` such that ``V(x) > ρ`` is
 ``\\lvert \\texttt{out\\_of\\_RoA\\_penalty}(V(x), V̇(x), x, x_0, ρ) \\rvert^2``.

--- a/src/minimization_conditions.jl
+++ b/src/minimization_conditions.jl
@@ -73,13 +73,13 @@ end
 
 Construct a [`LyapunovMinimizationCondition`](@ref) representing
     ``V(x) ≥ C \\lVert x - x_0 \\rVert^2``.
-If `check_fixed_point == true`, then training will also attempt to enforce
-    ``V(x_0) = 0``.
+If `check_fixed_point == true` (as is the default), then training will also attempt to
+enforce ``V(x_0) = 0``.
 
 The inequality is approximated by
     ``\\texttt{rectifier}(C \\lVert x - x_0 \\rVert^2 - V(x)) = 0``,
 and the default `rectifier` is the rectified linear unit `(t) -> max(zero(t), t)`, which
-exactly represents ``V(x) ≥ C \\lVert x - x_0 \\rVert^2``.
+exactly represents ``V(x) ≥ C \\lVert x - x_0 \\rVert^2``. ``C`` defaults to `1e-6`.
 """
 function StrictlyPositiveDefinite(;
         check_fixed_point = true,
@@ -124,11 +124,11 @@ Construct a [`LyapunovMinimizationCondition`](@ref) which represents not checkin
 nonnegativity of the Lyapunov function. This is appropriate in cases where this condition
 has been structurally enforced.
 
-It is still possible to check for ``V(x_0) = 0``, even in this case, for example if `V` is
-structured to be positive for ``x ≠ x_0``, but it is not guaranteed structurally that
-``V(x_0) = 0`` (such as [`NonnegativeNeuralLyapunov`](@ref)). `check_fixed_point` defaults
-to `true`, since in cases where ``V(x_0) = 0`` is enforced structurally, the equation will
-reduce to `0.0 ~ 0.0`, which gets removed in most cases.
+Even in this case, it is still possible to check for ``V(x_0) = 0``, for example if `V` is
+structured to be positive for ``x ≠ x_0`` but does not guarantee ``V(x_0) = 0`` (such as
+[`NonnegativeNeuralLyapunov`](@ref)). `check_fixed_point` defaults to `true`, since in cases
+where ``V(x_0) = 0`` is enforced structurally, the equation will reduce to `0.0 ~ 0.0`,
+which gets automatically removed in most cases.
 """
 function DontCheckNonnegativity(; check_fixed_point = true)::LyapunovMinimizationCondition
     LyapunovMinimizationCondition(

--- a/src/minimization_conditions.jl
+++ b/src/minimization_conditions.jl
@@ -41,7 +41,7 @@ that must be enforced in training for the Lyapunov function to be uniquely minim
     `check_nonnegativity = false;  check_fixed_point = true`.
 This can also be accomplished with [`DontCheckNonnegativity(true)`](@ref).
 
-In either case, the rectified linear unit `rectifier = (t) -> max(zero(t), t)` exactly
+In either case, the rectified linear unit `rectifier(t) = max(zero(t), t)` exactly
 represents the inequality, but differentiable approximations of this function may be
 employed.
 """
@@ -76,8 +76,10 @@ Construct a [`LyapunovMinimizationCondition`](@ref) representing
 If `check_fixed_point == true`, then training will also attempt to enforce
     ``V(x_0) = 0``.
 
-The inequality is represented by
-    ``\\texttt{rectifier}(C \\lVert x - x_0 \\rVert^2 - V(x)) = 0``.
+The inequality is approximated by
+    ``\\texttt{rectifier}(C \\lVert x - x_0 \\rVert^2 - V(x)) = 0``,
+and the default `rectifier` is the rectified linear unit `(t) -> max(zero(t), t)`, which
+exactly represents ``V(x) ≥ C \\lVert x - x_0 \\rVert^2``.
 """
 function StrictlyPositiveDefinite(;
         check_fixed_point = true,
@@ -93,15 +95,16 @@ function StrictlyPositiveDefinite(;
 end
 
 """
-    PositiveSemiDefinite(; check_fixed_point)
+    PositiveSemiDefinite(; check_fixed_point, rectifier)
 
-Construct a [`LyapunovMinimizationCondition`](@ref) representing
-    ``V(x) ≥ 0``.
-If `check_fixed_point == true`, then training will also attempt to enforce
-    ``V(x_0) = 0``.
+Construct a [`LyapunovMinimizationCondition`](@ref) representing ``V(x) ≥ 0``.
+If `check_fixed_point == true` (as is the default), then training will also attempt to
+enforce ``V(x_0) = 0``.
 
-The inequality is represented by
-    ``\\texttt{rectifier}( -V(x) ) = 0``."""
+The inequality is approximated by ``\\texttt{rectifier}( -V(x) ) = 0`` and the default
+`rectifier` is the rectified linear unit `(t) -> max(zero(t), t)`, which exactly represents
+``V(x) ≥ 0``.
+"""
 function PositiveSemiDefinite(;
         check_fixed_point = true,
         rectifier = (t) -> max(zero(t), t)

--- a/src/policy_search.jl
+++ b/src/policy_search.jl
@@ -9,8 +9,8 @@ Add dependence on the neural network to the dynamics in a [`NeuralLyapunovStruct
   - `new_dims::Integer`: number of outputs of the neural network to pass into the dynamics
     through `control_structure`.
   - `control_structure::Function`: transforms the final `new_dims` outputs of the neural net
-    before passing them into the dynamics; defaults to passing in the neural network outputs
-    unchanged.
+    before passing them into the dynamics; defaults to `identity`, passing in the neural
+    network outputs unchanged.
 
 The returned `NeuralLyapunovStructure` expects dynamics of the form `f(x, u, p, t)`, where
 `u` captures the dependence of dynamics on the neural network (e.g., through a control
@@ -68,8 +68,8 @@ vectors.
   - `network_dim`: total number of neural network outputs.
   - `control_dim`: number of neural network outputs used in the control policy.
   - `control_structure`: transforms the final `control_dim` outputs of the neural net before
-    passing them into the dynamics; defaults to passing in the neural network outputs
-    unchanged.
+    passing them into the dynamics; defaults to `identity`, passing in the neural network
+    outputs unchanged.
 """
 function get_policy(
         phi,

--- a/src/policy_search.jl
+++ b/src/policy_search.jl
@@ -8,6 +8,8 @@ Add dependence on the neural network to the dynamics in a [`NeuralLyapunovStruct
     assume dynamics take a form of `f(x, p, t)`.
   - `new_dims::Integer`: number of outputs of the neural network to pass into the dynamics
     through `control_structure`.
+
+# Keyword Arguments
   - `control_structure::Function`: transforms the final `new_dims` outputs of the neural net
     before passing them into the dynamics; defaults to `identity`, passing in the neural
     network outputs unchanged.
@@ -67,6 +69,8 @@ vectors.
     second (if there are multiple), and so on.
   - `network_dim`: total number of neural network outputs.
   - `control_dim`: number of neural network outputs used in the control policy.
+
+# Keyword Arguments
   - `control_structure`: transforms the final `control_dim` outputs of the neural net before
     passing them into the dynamics; defaults to `identity`, passing in the neural network
     outputs unchanged.

--- a/src/structure_specification.jl
+++ b/src/structure_specification.jl
@@ -32,7 +32,7 @@ This structure ensures ``V(x) ≥ 0 \\, ∀ x`` when ``δ ≥ 0`` and `pos_def` 
 nonnegative. Further, if ``δ > 0`` and `pos_def` is strictly positive definite around
 `fixed_point`, the structure ensures that ``V(x)`` is strictly positive away from
 `fixed_point`. In such cases, the minimization condition reduces to ensuring
-``V(\\texttt{fixed\\_point}) = 0``, and so [`DontCheckNonnegativity(true)`](@ref) should be
+``V(x_0) = 0``, and so [`DontCheckNonnegativity(true)`](@ref) should be
 used.
 
 # Arguments

--- a/src/structure_specification.jl
+++ b/src/structure_specification.jl
@@ -65,8 +65,7 @@ function NonnegativeNeuralLyapunov(
     if δ == 0.0
         NeuralLyapunovStructure(
             (net, state, fixed_point) -> net(state) ⋅ net(state),
-            (net, J_net, f, state, params, t, fixed_point) -> 2 *
-                                                              dot(
+            (net, J_net, f, state, params, t, fixed_point) -> 2 * dot(
                 net(state), J_net(state), f(state, params, t)),
             (f, net, state, p, t) -> f(state, p, t),
             network_dim
@@ -140,7 +139,7 @@ function PositiveSemiDefiniteStructure(
         grad_pos_def = nothing,
         grad_non_neg = nothing,
         grad = ForwardDiff.gradient
-)
+)::NeuralLyapunovStructure
     _grad(f::Function, x::AbstractArray{T}) where {T <: Num} = Symbolics.gradient(f(x), x)
     _grad(f::Function, x) = grad(f, x)
     grad_pos_def = if isnothing(grad_pos_def)

--- a/src/structure_specification.jl
+++ b/src/structure_specification.jl
@@ -20,13 +20,13 @@ function UnstructuredNeuralLyapunov()::NeuralLyapunovStructure
 end
 
 """
-    NonnegativeNeuralLyapunov(network_dim, δ, pos_def; grad_pos_def, grad)
+    NonnegativeNeuralLyapunov(network_dim; δ, pos_def, grad_pos_def, grad)
 
 Create a [`NeuralLyapunovStructure`](@ref) where the Lyapunov function is the L2 norm of the
 neural network output plus a constant δ times a function `pos_def`.
 
 Corresponds to ``V(x) = \\lVert ϕ(x) \\rVert^2 + δ \\, \\texttt{pos\\_def}(x, x_0)``, where
-``ϕ`` is the neural network and `x_0` is the equilibrium point.
+``ϕ`` is the neural network and ``x_0`` is the equilibrium point.
 
 This structure ensures ``V(x) ≥ 0 \\, ∀ x`` when ``δ ≥ 0`` and `pos_def` is always
 nonnegative. Further, if ``δ > 0`` and `pos_def` is strictly positive definite around
@@ -37,11 +37,11 @@ used.
 
 # Arguments
   - `network_dim`: output dimensionality of the neural network.
-  - `δ`: weight of `pos_def`, as above.
-  - `pos_def(state, fixed_point)`: a function that is postive (semi-)definite in `state`
-    around `fixed_point`; defaults to ``log(1 + \\lVert x - x_0 \\rVert^2)``.
 
 # Keyword Arguments
+  - `δ`: weight of `pos_def`, as above; defaults to 0.
+  - `pos_def(state, fixed_point)`: a function that is postive (semi-)definite in `state`
+    around `fixed_point`; defaults to ``\\log(1 + \\lVert x - x_0 \\rVert^2)``.
   - `grad_pos_def(state, fixed_point)`: the gradient of `pos_def` with respect to `state` at
     `state`. If `isnothing(grad_pos_def)` (as is the default), the gradient of `pos_def`
     will be evaluated using `grad`.
@@ -98,7 +98,7 @@ positive (semi-)definite function `pos_def` which does not depend on the network
 nonnegative function `non_neg` which does depend the network.
 
 Corresponds to ``V(x) = \\texttt{pos\\_def}(x, x_0) * \\texttt{non\\_neg}(ϕ, x, x_0)``, where
-``ϕ`` is the neural network and `x_0` is the equilibrium point.
+``ϕ`` is the neural network and ``x_0`` is the equilibrium point.
 
 This structure ensures ``V(x) ≥ 0``. Further, if `pos_def` is strictly positive definite
 `fixed_point` and `non_neg` is strictly positive (as is the case for the default values of
@@ -111,7 +111,7 @@ so [`DontCheckNonnegativity(false)`](@ref) should be used.
 
 # Keyword Arguments
   - `pos_def(state, fixed_point)`: a function that is postive (semi-)definite in `state`
-    around `fixed_point`; defaults to ``log(1 + \\lVert x - x_0 \\rVert^2)``.
+    around `fixed_point`; defaults to ``\\log(1 + \\lVert x - x_0 \\rVert^2)``.
   - `non_neg(net, state, fixed_point)`: a nonnegative function of the neural network; note
     that `net` is the neural network ``ϕ``, and `net(state)` is the value of the neural
     network at a point ``ϕ(x)``; defaults to ``1 + \\lVert ϕ(x) \\rVert^2``.

--- a/src/structure_specification.jl
+++ b/src/structure_specification.jl
@@ -20,7 +20,7 @@ function UnstructuredNeuralLyapunov()::NeuralLyapunovStructure
 end
 
 """
-    NonnegativeNeuralLyapunov(network_dim; δ, pos_def, grad_pos_def, grad)
+    NonnegativeNeuralLyapunov(network_dim; <keyword_arguments>)
 
 Create a [`NeuralLyapunovStructure`](@ref) where the Lyapunov function is the L2 norm of the
 neural network output plus a constant δ times a function `pos_def`.
@@ -91,7 +91,7 @@ function NonnegativeNeuralLyapunov(
 end
 
 """
-    PositiveSemiDefiniteStructure(network_dim; pos_def, non_neg, grad_pos_def, grad_non_neg, grad)
+    PositiveSemiDefiniteStructure(network_dim; <keyword_arguments>)
 
 Create a [`NeuralLyapunovStructure`](@ref) where the Lyapunov function is the product of a
 positive (semi-)definite function `pos_def` which does not depend on the network and a
@@ -123,7 +123,8 @@ so [`DontCheckNonnegativity(false)`](@ref) should be used.
     input. If `isnothing(grad_non_neg)` (as is the default), the gradient of `non_neg` will
     be evaluated using `grad`.
   - `grad`: a function for evaluating gradients to be used when `isnothing(grad_pos_def) ||
-    isnothing(grad_non_neg)`; defaults to, and expects the same arguments as, `ForwardDiff.gradient`.
+    isnothing(grad_non_neg)`; defaults to, and expects the same arguments as,
+    `ForwardDiff.gradient`.
 
 Dynamics are assumed to be in `f(state, p, t)` form, as in an `ODEFunction`. For
 `f(state, input, p, t)`, consider using [`add_policy_search`](@ref).

--- a/test/damped_pendulum.jl
+++ b/test/damped_pendulum.jl
@@ -1,4 +1,4 @@
-using NeuralPDE, Lux, ModelingToolkit, NeuralLyapunov
+using NeuralPDE, Lux, Boltz, ModelingToolkit, NeuralLyapunov
 import Optimization, OptimizationOptimisers, OptimizationOptimJL
 using Random
 using Test
@@ -43,7 +43,7 @@ dim_state = length(bounds)
 dim_hidden = 15
 dim_output = 2
 chain = [Lux.Chain(
-             PeriodicEmbedding([1], [2π]),
+             Boltz.Layers.PeriodicEmbedding([1], [2π]),
              Dense(3, dim_hidden, tanh),
              Dense(dim_hidden, dim_hidden, tanh),
              Dense(dim_hidden, 1, use_bias = false)

--- a/test/damped_pendulum.jl
+++ b/test/damped_pendulum.jl
@@ -66,10 +66,7 @@ minimization_condition = DontCheckNonnegativity(check_fixed_point = false)
 
 # Define Lyapunov decrease condition
 κ = 20.0
-decrease_condition = AsymptoticDecrease(
-    strict = true,
-    rectifier = (t) -> log(1.0 + exp(κ * t)) / κ
-)
+decrease_condition = AsymptoticStability(rectifier = (t) -> log(1.0 + exp(κ * t)) / κ)
 
 # Construct neural Lyapunov specification
 spec = NeuralLyapunovSpecification(

--- a/test/damped_sho.jl
+++ b/test/damped_sho.jl
@@ -47,7 +47,7 @@ minimization_condition = DontCheckNonnegativity(check_fixed_point = true)
 
 # Define Lyapunov decrease condition
 # Damped SHO has exponential decrease at a rate of k = ζ * ω_0, so we train to certify that
-decrease_condition = ExponentialDecrease(prod(p))
+decrease_condition = ExponentialStability(prod(p))
 
 # Construct neural Lyapunov specification
 spec = NeuralLyapunovSpecification(

--- a/test/inverted_pendulum.jl
+++ b/test/inverted_pendulum.jl
@@ -60,7 +60,7 @@ structure = add_policy_search(
 minimization_condition = DontCheckNonnegativity(check_fixed_point = false)
 
 # Define Lyapunov decrease condition
-decrease_condition = AsymptoticDecrease(strict = true)
+decrease_condition = AsymptoticStability()
 
 # Construct neural Lyapunov specification
 spec = NeuralLyapunovSpecification(

--- a/test/inverted_pendulum.jl
+++ b/test/inverted_pendulum.jl
@@ -1,4 +1,4 @@
-using NeuralPDE, Lux, NeuralLyapunov
+using NeuralPDE, Lux, Boltz, NeuralLyapunov
 import Optimization, OptimizationOptimisers, OptimizationOptimJL
 using Random
 using Test
@@ -34,7 +34,7 @@ dim_phi = 2
 dim_u = 1
 dim_output = dim_phi + dim_u
 chain = [Lux.Chain(
-             PeriodicEmbedding([1], [2π]),
+             Boltz.Layers.PeriodicEmbedding([1], [2π]),
              Dense(3, dim_hidden, tanh),
              Dense(dim_hidden, dim_hidden, tanh),
              Dense(dim_hidden, 1, use_bias = false)

--- a/test/inverted_pendulum_ODESystem.jl
+++ b/test/inverted_pendulum_ODESystem.jl
@@ -69,7 +69,7 @@ structure = add_policy_search(
 minimization_condition = DontCheckNonnegativity(check_fixed_point = false)
 
 # Define Lyapunov decrease condition
-decrease_condition = AsymptoticDecrease(strict = true)
+decrease_condition = AsymptoticStability()
 
 # Construct neural Lyapunov specification
 spec = NeuralLyapunovSpecification(
@@ -151,7 +151,7 @@ x0 = (ub .- lb) .* rand(2, 100) .+ lb
 
 using DifferentialEquations
 
-state_order = map(st -> SymbolicUtils.iscall(st) ? operation(st) : st, state_order)
+state_order = map(st -> SymbolicUtils.isterm(st) ? operation(st) : st, state_order)
 state_syms = Symbol.(state_order)
 
 closed_loop_dynamics = ODEFunction(

--- a/test/inverted_pendulum_ODESystem.jl
+++ b/test/inverted_pendulum_ODESystem.jl
@@ -1,4 +1,4 @@
-using NeuralPDE, Lux, ModelingToolkit, NeuralLyapunov
+using NeuralPDE, Lux, Boltz, ModelingToolkit, NeuralLyapunov
 import Optimization, OptimizationOptimisers, OptimizationOptimJL
 using Random
 using Test
@@ -43,7 +43,7 @@ dim_phi = 3
 dim_u = 1
 dim_output = dim_phi + dim_u
 chain = [Lux.Chain(
-             PeriodicEmbedding([1], [2π]),
+             Boltz.Layers.PeriodicEmbedding([1], [2π]),
              Dense(3, dim_hidden, tanh),
              Dense(dim_hidden, dim_hidden, tanh),
              Dense(dim_hidden, 1, use_bias = false)

--- a/test/roa_estimation.jl
+++ b/test/roa_estimation.jl
@@ -35,7 +35,7 @@ structure = PositiveSemiDefiniteStructure(dim_output)
 minimization_condition = DontCheckNonnegativity()
 
 # Define Lyapunov decrease condition
-decrease_condition = make_RoA_aware(AsymptoticStability())
+decrease_condition = make_RoA_aware(StabilityISL())
 
 # Construct neural Lyapunov specification
 spec = NeuralLyapunovSpecification(

--- a/test/roa_estimation.jl
+++ b/test/roa_estimation.jl
@@ -35,7 +35,7 @@ structure = PositiveSemiDefiniteStructure(dim_output)
 minimization_condition = DontCheckNonnegativity()
 
 # Define Lyapunov decrease condition
-decrease_condition = make_RoA_aware(AsymptoticDecrease(strict = true))
+decrease_condition = make_RoA_aware(AsymptoticStability())
 
 # Construct neural Lyapunov specification
 spec = NeuralLyapunovSpecification(


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Decrease conditions `AsymptoticDecrease` and `ExponentialDecrease` are being renamed `AsymptoticStability` and `ExponentialStability`. Additionally, their `strict` option is being removed for increased simplicity and `StabilityISL` is being added to cover the `strict = false` case from `AsymptoticDecrease`, which should be a clearer/more accurate name.

Furthermore, this PR fixes many documentation typos.