### PR TITLE
Modifies `RoAAwareDecreaseCondition` to work with a general `AbstractLyapunovDecreaseCondition` instead of being limited to a `LyapunovDecreaseCondition`

### DIFF
--- a/src/decrease_conditions_RoA_aware.jl
+++ b/src/decrease_conditions_RoA_aware.jl
@@ -1,19 +1,12 @@
 """
-    RoAAwareDecreaseCondition(check_decrease, rate_metric, strength, rectifier, ρ, out_of_RoA_penalty)
+    RoAAwareDecreaseCondition(cond, sigmoid, ρ, out_of_RoA_penalty)
 
 Specifies the form of the Lyapunov decrease condition to be used, training for a region of
 attraction estimate of ``\\{ x : V(x) ≤ ρ \\}``.
 
 # Fields
-  - `check_decrease::Bool`: whether or not to train for negativity/nonpositivity of
-    ``V̇(x)``.
-  - `rate_metric::Function`: should increase with ``V̇(x)``; used when
-    `check_decrease == true`.
-  - `strength::Function`: specifies the level of strictness for negativity training; should
-    be zero when the two inputs are equal and nonnegative otherwise; used when
-    `check_decrease == true`.
-  - `rectifier::Function`: positive when the input is positive and (approximately) zero when
-    the input is negative.
+  - `cond::AbstractLyapunovDecreaseCondition`: specifies the loss to be applied when
+    ``V(x) ≤ ρ``.
   - `sigmoid::Function`: approximately one when the input is positive and approximately zero
     when the input is negative.
   - `ρ`: the level of the sublevel set forming the estimate of the region of attraction.
@@ -22,25 +15,12 @@ attraction estimate of ``\\{ x : V(x) ≤ ρ \\}``.
 
 # Training conditions
 
-If `check_decrease == true`, training will attempt to enforce
-
-``\\texttt{rate\\_metric}(V(x), V̇(x)) ≤ - \\texttt{strength}(x, x_0)``
-
-whenever ``V(x) ≤ ρ``, and will instead apply a loss of
-
-``\\lvert \\texttt{out\\_of\\_RoA\\_penalty}(V(x), V̇(x), x, x_0, ρ) \\rvert^2``
-
-when ``V(x) > ρ``.
-
-The inequality will be approximated by the equation
-
-``\\texttt{rectifier}(\\texttt{rate\\_metric}(V(x), V̇(x)) + \\texttt{strength}(x, x_0)) = 0``.
-
-Note that the approximate equation and inequality are identical when
-``\\texttt{rectifier}(t) = \\max(0, t)``.
+Inside the region of attraction (i.e., when ``V(x) ≤ ρ``), the loss function specified by
+`cond` will be applied. Outside the region of attraction (i.e., when ``V(x) > ρ``), the loss
+function specified by `out_of_RoA_penalty` will be applied.
 
 The `sigmoid` function allows for a smooth transition between the ``V(x) ≤ ρ`` case and the
-``V(x) > ρ`` case, by combining the above equations into one:
+``V(x) > ρ`` case, by combining the different losses into one:
 
 ``\\texttt{sigmoid}(ρ - V(x)) (\\text{in-RoA expression}) + \\texttt{sigmoid}(V(x) - ρ) (\\text{out-of-RoA expression}) = 0``.
 
@@ -56,14 +36,15 @@ to train for ``V̇(x_0) = 0``.
 
 Asymptotic decrease can be enforced by requiring
     ``V̇(x) ≤ -C \\lVert x - x_0 \\rVert^2``,
-for some positive ``C``, which corresponds to
+for some positive ``C``, which can be represented by a [`LyapunovDecreaseCondition`](@ref)
+with
 
     rate_metric = (V, dVdt) -> dVdt
     strength = (x, x0) -> C * (x - x0) ⋅ (x - x0)
 
 Exponential decrease of rate ``k`` is proven by
     ``V̇(x) ≤ - k V(x)``,
-which corresponds to
+which can be represented by a [`LyapunovDecreaseCondition`](@ref) with
 
     rate_metric = (V, dVdt) -> dVdt + k * V
     strength = (x, x0) -> 0.0
@@ -87,29 +68,23 @@ employed.
 See also: [`LyapunovDecreaseCondition`](@ref)
 """
 struct RoAAwareDecreaseCondition <: AbstractLyapunovDecreaseCondition
-    check_decrease::Bool
-    rate_metric::Function
-    strength::Function
-    rectifier::Function
+    cond::AbstractLyapunovDecreaseCondition
     sigmoid::Function
     ρ::Real
     out_of_RoA_penalty::Function
 end
 
-function check_decrease(cond::RoAAwareDecreaseCondition)::Bool
-    cond.check_decrease
-end
+check_decrease(cond::RoAAwareDecreaseCondition)::Bool = check_decrease(cond.cond)
 
 function get_decrease_condition(cond::RoAAwareDecreaseCondition)
-    if cond.check_decrease
+    if check_decrease(cond)
+        in_RoA_penalty = get_decrease_condition(cond.cond)
         return function (V, dVdt, x, fixed_point)
             _V = V(x)
             _V = _V isa AbstractVector ? _V[] : _V
             _V̇ = dVdt(x)
             _V̇ = _V̇ isa AbstractVector ? _V̇[] : _V̇
-            return cond.sigmoid(cond.ρ - _V) * cond.rectifier(
-                cond.rate_metric(_V, _V̇) + cond.strength(x, fixed_point)
-            ) +
+            return cond.sigmoid(cond.ρ - _V) * in_RoA_penalty(V, dVdt, x, fixed_point) +
                    cond.sigmoid(_V - cond.ρ) *
                    cond.out_of_RoA_penalty(_V, _V̇, x, fixed_point, cond.ρ)
         end
@@ -122,7 +97,7 @@ end
     make_RoA_aware(cond; ρ, out_of_RoA_penalty, sigmoid)
 
 Add awareness of the region of attraction (RoA) estimation task to the supplied
-[`LyapunovDecreaseCondition`](@ref).
+[`AbstractLyapunovDecreaseCondition`](@ref).
 
 When estimating the region of attraction using a Lyapunov function, the decrease condition
 only needs to be met within a bounded sublevel set ``\\{ x : V(x) ≤ ρ \\}``.
@@ -130,7 +105,8 @@ The returned [`RoAAwareDecreaseCondition`](@ref) enforces the decrease condition
 by `cond` only in that sublevel set.
 
 # Arguments
-  - `cond::LyapunovDecreaseCondition`: specifies the loss to be applied when ``V(x) ≤ ρ``.
+  - `cond::AbstractLyapunovDecreaseCondition`: specifies the loss to be applied when
+  ``V(x) ≤ ρ``.
 
 # Keyword Arguments
   - `ρ`: the target level such that the RoA will be ``\\{ x : V(x) ≤ ρ \\}``, defaults to 1.
@@ -155,16 +131,13 @@ As such, the default value is `sigmoid(t) = t ≥ zero(t)`.
 See also: [`RoAAwareDecreaseCondition`](@ref)
 """
 function make_RoA_aware(
-        cond::LyapunovDecreaseCondition;
+        cond::AbstractLyapunovDecreaseCondition;
         ρ = 1.0,
         out_of_RoA_penalty = (V, dVdt, state, fixed_point, _ρ) -> 0.0,
         sigmoid = (x) -> x .≥ zero.(x)
 )::RoAAwareDecreaseCondition
     RoAAwareDecreaseCondition(
-        cond.check_decrease,
-        cond.rate_metric,
-        cond.strength,
-        cond.rectifier,
+        cond,
         sigmoid,
         ρ,
         out_of_RoA_penalty

--- a/src/decrease_conditions_RoA_aware.jl
+++ b/src/decrease_conditions_RoA_aware.jl
@@ -65,7 +65,7 @@ In any of these cases, the rectified linear unit `rectifier = (t) -> max(zero(t)
 exactly represents the inequality, but differentiable approximations of this function may be
 employed.
 
-See also: [`LyapunovDecreaseCondition`](@ref)
+See also: [`AbstractLyapunovDecreaseCondition`](@ref), [`LyapunovDecreaseCondition`](@ref)
 """
 struct RoAAwareDecreaseCondition <: AbstractLyapunovDecreaseCondition
     cond::AbstractLyapunovDecreaseCondition

--- a/test/damped_sho_CUDA.jl
+++ b/test/damped_sho_CUDA.jl
@@ -7,7 +7,7 @@ using Test, LinearAlgebra, ForwardDiff, StableRNGs
 rng = StableRNG(0)
 Random.seed!(200)
 
-println("Damped Simple Harmonic Oscillator")
+println("Damped Simple Harmonic Oscillator (CUDA)")
 
 ######################### Define dynamics and domain ##########################
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API