### PR TITLE
`benchmark` now outputs a `NamedTuple`

### DIFF
--- a/docs/src/man/benchmarking.md
+++ b/docs/src/man/benchmarking.md
@@ -4,7 +4,7 @@ To facilitate comparison of different neural Lyapunov specifications, optimizers
 
 Through its arguments, users may specify how a neural Lyapunov problem, the neural network structure, the physics-informed neural network discretization strategy, and the optimization strategy used to solve the problem.
 After solving the problem in the specified manner, the dynamical system is simulated (users can specify an ODE solver in the arguments, as well) and classification by the neural Lyapunov function is compared to the simulation results.
-By default, the [`benchmark`](@ref) function returns a confusion matrix for the resultant neural Lyapunov classifier and the training time, so that users can compare accuracy and computation speed of various methods.
+The [`benchmark`](@ref) function returns a confusion matrix for the resultant neural Lyapunov classifier, the training time, and samples with labels, so that users can compare accuracy and computation speed of various methods.
 
 ```@docs
 benchmark

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -61,7 +61,7 @@ using Test
     optimization_args = [:maxiters => 450]
 
     # Run benchmark
-    cm, time = benchmark(
+    out = benchmark(
         sho,
         lb,
         ub,
@@ -74,6 +74,7 @@ using Test
         p = p,
         optimization_args = optimization_args
     )
+    cm = out.confusion_matrix
 
     # SHO is globally asymptotically stable
     @test cm.n == 0
@@ -153,7 +154,7 @@ end
 
     # Run benchmark
     endpoint_check = (x) -> ≈([sin(x[1]), cos(x[1]), x[2]], [0, -1, 0], atol = 5e-3)
-    (cm, training_time), (states, endpoints, actual, predicted, V_samples, V̇_samples) = benchmark(
+    out = benchmark(
         open_loop_pendulum_dynamics,
         lb,
         ub,
@@ -171,9 +172,9 @@ end
         policy_search = true,
         endpoint_check,
         classifier = (V, V̇, x) -> V̇ < zero(V̇) || endpoint_check(x),
-        verbose = true,
         init_params = ps
     )
+    cm = out.confusion_matrix
 
     # Resulting controller should drive more states to equilibrium than not
     @test cm.p > cm.n
@@ -252,7 +253,7 @@ end
     optimization_args = [:maxiters => 600]
 
     # Run benchmark
-    cm, time = benchmark(
+    out = benchmark(
         damped_pendulum,
         bounds,
         spec,
@@ -265,6 +266,7 @@ end
         endpoint_check = (x) -> ≈([sin(x[1]), cos(x[1]), x[2]], [0, 1, 0], atol = 1e-3),
         rng = StableRNG(0)
     )
+    cm = out.confusion_matrix
 
     # Damped pendulum is globally asymptotically stable, except at upright equilibrium
     @test cm.n == 2


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

`benchmark` now outputs a `NamedTuple`, removing `verbose` keyword
