### PR TITLE
Fixes `benchmark` when using multiple optimizers

### DIFF
--- a/src/NeuralLyapunov.jl
+++ b/src/NeuralLyapunov.jl
@@ -6,11 +6,12 @@ using LinearAlgebra
 using ModelingToolkit
 import SciMLBase
 using NeuralPDE
-import OrdinaryDiffEq: Tsit5
-import EvalMetrics: ConfusionMatrix
+using OrdinaryDiffEq: Tsit5
+using EvalMetrics: ConfusionMatrix
 import LuxCore
-import StableRNGs: StableRNG
-import QuasiMonteCarlo: sample, LatinHypercubeSample
+using StableRNGs: StableRNG
+using QuasiMonteCarlo: sample, LatinHypercubeSample
+using Optimization: remake
 
 include("conditions_specification.jl")
 include("structure_specification.jl")

--- a/src/benchmark_harness.jl
+++ b/src/benchmark_harness.jl
@@ -344,7 +344,7 @@ function benchmark_solve(prob, opt::AbstractVector, optimization_args)
     res = Ref{Any}()
     for i in eachindex(opt)
         _res = solve(prob, opt[i]; optimization_args...)
-        prob = Optimization.remake(prob, u0 = _res.u)
+        prob = remake(prob, u0 = _res.u)
         res[] = _res
     end
 

--- a/src/benchmark_harness.jl
+++ b/src/benchmark_harness.jl
@@ -83,8 +83,8 @@ arguments for each optimization pass.
     endpoint is approximately the fixed point and `false` otherwise; defaults to
     `(x) -> ≈(x, fixed_point; atol=atol)`.
   - `atol`: absolute tolerance used in the default value for `endpoint_check`.
-  - `init_params`: initial parameters for the neural network; defaults to `nothing`, in which
-    case the initial parameters are generated using `Lux.initialparameters` and `rng`.
+  - `init_params`: initial parameters for the neural network; defaults to `nothing`, in
+    which case the initial parameters are generated using `Lux.initialparameters` and `rng`.
   - `rng`: random number generator used to generate initial parameters; defaults to a
     `StableRNG` with seed `0`.
 
@@ -267,7 +267,7 @@ function _benchmark(
 )
     t = @timed begin
         # Construct OptimizationProblem
-        discretization = PhysicsInformedNN(chain, strategy; init_params = init_params)
+        discretization = PhysicsInformedNN(chain, strategy; init_params)
         opt_prob = discretize(pde_system, discretization)
 
         # Solve OptimizationProblem
@@ -284,7 +284,7 @@ function _benchmark(
         spec.structure,
         f,
         fixed_point;
-        p = p
+        p
     )
 
     f = let fc = spec.structure.f_call, _f = f,

--- a/src/benchmark_harness.jl
+++ b/src/benchmark_harness.jl
@@ -329,8 +329,8 @@ function benchmark_solve(
 )
     # Solve OptimizationProblem
     res = Ref{Any}()
-    for i in eachindex(opt)
-        _res = solve(prob, opt[i]; optimization_args[i]...)
+    for (_opt, args) in zip(opt, optimization_args)
+        _res = solve(prob, _opt; args...)
         prob = remake(prob, u0 = _res.u)
         res[] = _res
     end
@@ -342,8 +342,8 @@ end
 function benchmark_solve(prob, opt::AbstractVector, optimization_args)
     # Solve OptimizationProblem
     res = Ref{Any}()
-    for i in eachindex(opt)
-        _res = solve(prob, opt[i]; optimization_args...)
+    for _opt in opt
+        _res = solve(prob, _opt; optimization_args...)
         prob = remake(prob, u0 = _res.u)
         res[] = _res
     end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Was erroring in some cases due to `Optimization.remake` not being imported.