### PR TITLE
Fixes `benchmark` when `chain` is not an array

### DIFF
--- a/src/benchmark_harness.jl
+++ b/src/benchmark_harness.jl
@@ -271,8 +271,11 @@ function _benchmark(
         opt_prob = discretize(pde_system, discretization)
 
         # Solve OptimizationProblem
-        θ = benchmark_solve(opt_prob, opt, optimization_args)
+        u = benchmark_solve(opt_prob, opt, optimization_args)
+
+        # Get parameters from optimization result
         phi = discretization.phi
+        θ = phi isa AbstractArray ? u.depvar : u
         (θ, phi)
     end
     training_time = t.time
@@ -318,8 +321,8 @@ function benchmark_solve(prob, opt, optimization_args)
     # Solve OptimizationProblem
     res = solve(prob, opt; optimization_args...)
 
-    # Return parameters θ
-    return res.u.depvar
+    # Return optimization result
+    return res.u
 end
 
 function benchmark_solve(
@@ -335,8 +338,8 @@ function benchmark_solve(
         res[] = _res
     end
 
-    # Return parameters θ
-    return res[].u.depvar
+    # Return optimization result
+    return res[].u
 end
 
 function benchmark_solve(prob, opt::AbstractVector, optimization_args)
@@ -348,8 +351,8 @@ function benchmark_solve(prob, opt::AbstractVector, optimization_args)
         res[] = _res
     end
 
-    # Return parameters
-    return res[].u.depvar
+    # Return optimization result
+    return res[].u
 end
 
 function get_endpoint(

--- a/src/numerical_lyapunov_functions.jl
+++ b/src/numerical_lyapunov_functions.jl
@@ -10,9 +10,10 @@ These functions can operate on a state vector or columnwise on a matrix of state
 # Positional Arguments
   - `phi`: the neural network, represented as `phi(x, θ)` if the neural network has a single
     output, or a `Vector` of the same with one entry per neural network output.
-  - `θ`: the parameters of the neural network; `θ[:φ1]` should be the parameters of the
-    first neural network output (even if there is only one), `θ[:φ2]` the parameters of the
-    second (if there are multiple), and so on.
+  - `θ`: the parameters of the neural network; If the neural network has multiple outputs,
+    `θ[:φ1]` should be the parameters of the first neural network output, `θ[:φ2]` the
+    parameters of the second (if there are multiple), and so on. If the neural network has a
+    single output, `θ` should be the parameters of the network.
   - `structure`: a [`NeuralLyapunovStructure`](@ref) representing the structure of the
     neural Lyapunov function.
   - `dynamics`: the system dynamics, as a function to be used in conjunction with
@@ -102,16 +103,15 @@ Return the network as a function of state alone.
 # Arguments
   - `phi`: the neural network, represented as `phi(x, θ)` if the neural network has a single
     output, or a `Vector` of the same with one entry per neural network output.
-  - `θ`: the parameters of the neural network; `θ[:φ1]` should be the parameters of the
-    first neural network output (even if there is only one), `θ[:φ2]` the parameters of the
-    second (if there are multiple), and so on.
+  - `θ`: the parameters of the neural network; If the neural network has multiple outputs,
+    `θ[:φ1]` should be the parameters of the first neural network output, `θ[:φ2]` the
+    parameters of the second (if there are multiple), and so on. If the neural network has a
+    single output, `θ` should be the parameters of the network.
   - `idx`: the neural network outputs to include in the returned function; defaults to all
     and only applicable when `phi isa Vector`.
 """
 function phi_to_net(phi, θ)
-    let _θ = θ, φ = phi
-        return (x) -> φ(x, _θ[:φ1])
-    end
+    return Base.Fix2(phi, θ)
 end
 
 function phi_to_net(phi::Vector, θ; idx = eachindex(phi))

--- a/test/damped_sho_CUDA.jl
+++ b/test/damped_sho_CUDA.jl
@@ -80,7 +80,7 @@ res = Optimization.solve(prob, OptimizationOptimJL.BFGS(); maxiters = 300)
 ###################### Get numerical numerical functions ######################
 V, V̇ = get_numerical_lyapunov_function(
     discretization.phi,
-    (; φ1 = res.u),
+    res.u,
     structure,
     f,
     fixed_point


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Fixes `benchmark` when `chain` is not an array, but does change the interface of `get_numerical_lyapunov_function` in that case.