### PR TITLE
Rename `UnstructuredNeuralLyapunov` and `NonnegativeNeuralLyapunov` to `NoAdditionalStructure` and `NonnegativeStructure`, respectively.

### DIFF
--- a/docs/src/demos/damped_SHO.md
+++ b/docs/src/demos/damped_SHO.md
@@ -56,7 +56,7 @@ strategy = QuasiRandomTraining(1000)
 discretization = PhysicsInformedNN(chain, strategy; init_params = ps)
 
 # Define neural Lyapunov structure
-structure = NonnegativeNeuralLyapunov(
+structure = NonnegativeStructure(
     dim_output;
     δ = 1e-6
 )
@@ -179,7 +179,7 @@ To train for exponential stability we use [`ExponentialStability`](@ref), but we
 using NeuralLyapunov
 
 # Define neural Lyapunov structure
-structure = NonnegativeNeuralLyapunov(
+structure = NonnegativeStructure(
     dim_output;
     δ = 1e-6
 )

--- a/docs/src/man/structure.md
+++ b/docs/src/man/structure.md
@@ -4,20 +4,20 @@ Three simple neural Lyapunov function structures are provided, but users can alw
 
 ## Pre-defined structures
 
-The simplest structure is to train the neural network directly to be the Lyapunov function, which can be accomplished using an [`UnstructuredNeuralLyapunov`](@ref).
+The simplest structure is to train the neural network directly to be the Lyapunov function, which can be accomplished using an [`NoAdditionalStructure`](@ref).
 
 ```@docs
-UnstructuredNeuralLyapunov
+NoAdditionalStructure
 ```
 
 The condition that the Lyapunov function ``V(x)`` must be minimized uniquely at the fixed point ``x_0`` is often represented as a requirement for ``V(x)`` to be positive away from the fixed point and zero at the fixed point.
 Put mathematically, it is sufficient to require ``V(x) > 0 \, \forall x \ne x_0`` and ``V(x_0) = 0``.
 We call such functions positive definite (around the fixed point ``x_0``).
 
-Two structures are provided which partially or fully enforce the minimization condition: [`NonnegativeNeuralLyapunov`](@ref), which structurally enforces ``V(x) \ge 0`` everywhere, and [`PositiveSemiDefiniteStructure`](@ref), which additionally enforces ``V(x_0) = 0``.
+Two structures are provided which partially or fully enforce the minimization condition: [`NonnegativeStructure`](@ref), which structurally enforces ``V(x) \ge 0`` everywhere, and [`PositiveSemiDefiniteStructure`](@ref), which additionally enforces ``V(x_0) = 0``.
 
 ```@docs
-NonnegativeNeuralLyapunov
+NonnegativeStructure
 PositiveSemiDefiniteStructure
 ```
 

--- a/src/NeuralLyapunov.jl
+++ b/src/NeuralLyapunov.jl
@@ -32,7 +32,7 @@ include("policy_search.jl")
 include("benchmark_harness.jl")
 
 # Lyapunov function structures
-export NeuralLyapunovStructure, UnstructuredNeuralLyapunov, NonnegativeNeuralLyapunov,
+export NeuralLyapunovStructure, NoAdditionalStructure, NonnegativeStructure,
        PositiveSemiDefiniteStructure, get_numerical_lyapunov_function
 
 # Minimization conditions

--- a/src/minimization_conditions.jl
+++ b/src/minimization_conditions.jl
@@ -130,7 +130,7 @@ has been structurally enforced.
 
 Even in this case, it is still possible to check for ``V(x_0) = 0``, for example if `V` is
 structured to be positive for ``x ≠ x_0`` but does not guarantee ``V(x_0) = 0`` (such as
-[`NonnegativeNeuralLyapunov`](@ref)). `check_fixed_point` defaults to `true`, since in cases
+[`NonnegativeStructure`](@ref)). `check_fixed_point` defaults to `true`, since in cases
 where ``V(x_0) = 0`` is enforced structurally, the equation will reduce to `0.0 ~ 0.0`,
 which gets automatically removed in most cases.
 """

--- a/src/structure_specification.jl
+++ b/src/structure_specification.jl
@@ -1,15 +1,16 @@
 """
-    UnstructuredNeuralLyapunov()
+    NoAdditionalStructure()
 
 Create a [`NeuralLyapunovStructure`](@ref) where the Lyapunov function is the neural network
-evaluated at the state. This does not structurally enforce any Lyapunov conditions.
+evaluated at the state. This does impose any additional structure to enforce any Lyapunov
+conditions.
 
 Corresponds to ``V(x) = ϕ(x)``, where ``ϕ`` is the neural network.
 
 Dynamics are assumed to be in `f(state, p, t)` form, as in an `ODEFunction`. For
 `f(state, input, p, t)`, consider using [`add_policy_search`](@ref).
 """
-function UnstructuredNeuralLyapunov()::NeuralLyapunovStructure
+function NoAdditionalStructure()::NeuralLyapunovStructure
     NeuralLyapunovStructure(
         (net, state, fixed_point) -> net(state),
         (net, grad_net, f, state, params, t, fixed_point) -> grad_net(state) ⋅
@@ -20,7 +21,7 @@ function UnstructuredNeuralLyapunov()::NeuralLyapunovStructure
 end
 
 """
-    NonnegativeNeuralLyapunov(network_dim; <keyword_arguments>)
+    NonnegativeStructure(network_dim; <keyword_arguments>)
 
 Create a [`NeuralLyapunovStructure`](@ref) where the Lyapunov function is the L2 norm of the
 neural network output plus a constant δ times a function `pos_def`.
@@ -53,7 +54,7 @@ Dynamics are assumed to be in `f(state, p, t)` form, as in an `ODEFunction`. For
 
 See also: [`DontCheckNonnegativity`](@ref)
 """
-function NonnegativeNeuralLyapunov(
+function NonnegativeStructure(
         network_dim::Integer;
         δ::Real = 0.0,
         pos_def::Function = (state, fixed_point) -> log(1.0 +

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -40,7 +40,7 @@ using Test
     strategy = QuasiRandomTraining(1000)
 
     # Define neural Lyapunov structure
-    structure = NonnegativeNeuralLyapunov(
+    structure = NonnegativeStructure(
         dim_output;
         δ = 1e-6
     )

--- a/test/damped_sho.jl
+++ b/test/damped_sho.jl
@@ -41,7 +41,7 @@ strategy = QuasiRandomTraining(1000)
 discretization = PhysicsInformedNN(chain, strategy; init_params = ps)
 
 # Define neural Lyapunov structure
-structure = NonnegativeNeuralLyapunov(
+structure = NonnegativeStructure(
     dim_output;
     δ = 5.0
 )

--- a/test/damped_sho_CUDA.jl
+++ b/test/damped_sho_CUDA.jl
@@ -41,7 +41,7 @@ strategy = QuasiRandomTraining(2500)
 discretization = PhysicsInformedNN(chain, strategy; init_params = ps)
 
 # Define neural Lyapunov structure
-structure = UnstructuredNeuralLyapunov()
+structure = NoAdditionalStructure()
 minimization_condition = StrictlyPositiveDefinite(C = 0.1)
 
 # Define Lyapunov decrease condition
@@ -101,7 +101,7 @@ V̇_samples = V̇_samples_gpu |> cpud
 
 #################################### Tests ####################################
 
-# Network structure should enforce nonegativeness of V
+# Network structure should enforce nonnegativeness of V
 V0 = (V(fixed_point) |> cpud)[]
 V_min, i_min = findmin(V_samples)
 state_min = collect(states)[i_min]


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

For more homogoneity with `PositiveDefiniteStructure`. Additionally, it's a neural Lyapunov package, so it's better to signal that these are structures not that they belong in this package.