### PR TITLE
Adds `AdditiveLyapunovNet` and `MultiplicativeLyapunovNet`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,12 @@ authors = ["Nicholas Klugman <13633349+nicholaskl97@users.noreply.github.com>"]
 version = "0.2.0"
 
 [deps]
+Boltz = "4544d5e4-abc5-4dea-817f-29e4c205d9c8"
 EvalMetrics = "251d5f9e-10c1-4699-ba24-e0ad168fa3e4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
 LuxCore = "bb33d45b-7691-41d6-9220-0943567d0623"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 NeuralPDE = "315f7962-48a3-4962-8226-d0f33b1235f0"
@@ -51,11 +53,9 @@ julia = "1.11"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-Boltz = "4544d5e4-abc5-4dea-817f-29e4c205d9c8"
 CSDP = "0a46da34-8e4b-519e-b418-48813639ff34"
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
-Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
 LuxCUDA = "d0bbae9a-e099-4d5b-a835-1c6931763bda"
 NLopt = "76087f3c-5699-56af-9a33-bf431cd00edd"
 NeuralPDE = "315f7962-48a3-4962-8226-d0f33b1235f0"
@@ -67,4 +67,4 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["SafeTestsets", "Test", "Lux", "Optimization", "OptimizationOptimJL", "OptimizationOptimisers", "NLopt", "Random", "NeuralPDE", "CSDP", "Boltz", "ComponentArrays", "LuxCUDA", "Aqua", "ExplicitImports"]
+test = ["SafeTestsets", "Test", "Optimization", "OptimizationOptimJL", "OptimizationOptimisers", "NLopt", "Random", "NeuralPDE", "CSDP", "ComponentArrays", "LuxCUDA", "Aqua", "ExplicitImports"]

--- a/docs/ref.bib
+++ b/docs/ref.bib
@@ -9,3 +9,20 @@
   keywords={Trajectory;Angular velocity;Acceleration;Rotors;Aerodynamics;Force;Optimization},
   doi={10.1109/ICRA.2011.5980409}
 }
+
+@article{gaby_lyapunov-net_2021,
+  author       = {Nathan Gaby and
+                  Fumin Zhang and
+                  Xiaojing Ye},
+  title        = {Lyapunov-Net: {A} Deep Neural Network Architecture for Lyapunov Function
+                  Approximation},
+  journal      = {CoRR},
+  volume       = {abs/2109.13359},
+  year         = {2021},
+  url          = {https://arxiv.org/abs/2109.13359},
+  eprinttype    = {arXiv},
+  eprint       = {2109.13359},
+  timestamp    = {Sun, 26 Mar 2023 14:05:31 +0200},
+  biburl       = {https://dblp.org/rec/journals/corr/abs-2109-13359.bib},
+  bibsource    = {dblp computer science bibliography, https://dblp.org}
+}

--- a/docs/src/man/structure.md
+++ b/docs/src/man/structure.md
@@ -40,6 +40,8 @@ Regardless of what NeuralLyapunov transformation is used to transform ``\phi`` i
 Two options provided by NeuralLyapunov, intended to be used with [`NoAdditionalStructure`](@ref), are [`AdditiveLyapunovNet`](@ref) and [`MultiplicativeLyapunovNet`](@ref).
 These each wrap a different Lux model, effectively performing the transformation from ``\phi`` to ``V`` within the Lux ecosystem, rather than in the NeuralPDE/ModelingToolkit symbolic ecosystem. 
 
+[`AdditiveLyapunovNet`](@ref) is based on [gaby_lyapunov-net_2021](@cite), and [`MultiplicativeLyapunovNet`](@ref) is an analogous structure combining the neural term and the positive definite term via multiplication instead of addition.
+
 ```@docs
 AdditiveLyapunovNet
 MultiplicativeLyapunovNet
@@ -90,3 +92,8 @@ Note that this form allows ``V(x)`` to depend on the neural network evaluated at
 The time derivative ``\dot{V}`` is similarly defined by a function `V̇(phi, J_phi, dynamics, state, params, t, fixed_point)`.
 The function `J_phi(state)` gives the Jacobian of the neural network `phi` at `state`.
 The function `dynamics` is as above (with parameters `params`). 
+
+## References
+```@bibliography
+Pages = ["structure.md"]
+```

--- a/docs/src/man/structure.md
+++ b/docs/src/man/structure.md
@@ -1,10 +1,23 @@
 # Structuring a Neural Lyapunov function
 
-Three simple neural Lyapunov function structures are provided, but users can always specify a custom structure using the [`NeuralLyapunovStructure`](@ref) struct.
+Users have two ways to specify the structure of their neural Lyapunov function: through Lux and through NeuralLyapunov.
+NeuralLyapunov.jl is intended for use with [NeuralPDE.jl](https://github.com/SciML/NeuralPDE.jl), which is itself intended for use with [Lux.jl](https://github.com/LuxDL/Lux.jl).
+Users therefore must provide a Lux model representing the neural network ``\phi(x)`` which will be trained, regardless of the transformation they use to go from ``\phi`` to ``V``.
 
-## Pre-defined structures
+In some cases, users will find it simplest to make ``\phi(x)`` a simple multilayer perceptron and specify their neural Lyapunov function structure as a transformation of the function ``\phi`` to the function ``V`` using the [`NeuralLyapunovStructure`](@ref) struct, detailed below.
+
+In other cases (particularly when they find the NeuralPDE parser has trouble tracing their structure), users may wish to represent their neuralLyapunov function structure using [Lux.jl](https://github.com/LuxDL/Lux.jl)/[Boltz.jl](https://github.com/LuxDL/Boltz.jl) layers, integrating them into ``\phi(x)`` and letting ``V(x) = \phi(x)`` (as in [`NoAdditionalStructure`](@ref), detailed below).
+
+Users may also combine the two methods, particularly if they find that their structure can be broken down into a component that the NeuralPDE parser has trouble tracing but exists in Lux/Boltz, and another aspect that can be written easily using a [`NeuralLyapunovStructure`](@ref) but does not correspond any existing Lux/Boltz layer.
+(Such an example will be provided below.)
+
+NeuralLyapunov.jl supplies two Lux structures and two pooling layers for structuring ``\phi(x)``, along with three [`NeuralLyapunovStructure`](@ref) transformations.
+Additionally, users can always specify a custom structure using the [`NeuralLyapunovStructure`](@ref) struct.
+
+## Pre-defined NeuralLyapunov transformations
 
 The simplest structure is to train the neural network directly to be the Lyapunov function, which can be accomplished using an [`NoAdditionalStructure`](@ref).
+This is particularly useful with the pre-defined Lux structures detailed in the following section.
 
 ```@docs
 NoAdditionalStructure
@@ -21,7 +34,29 @@ NonnegativeStructure
 PositiveSemiDefiniteStructure
 ```
 
-## Defining your own neural Lyapunov function structure
+## Pre-defined Lux structures
+
+Regardless of what NeuralLyapunov transformation is used to transform ``\phi`` into ``V``, users should carefully consider their choice of ``\phi``.
+Two options provided by NeuralLyapunov, intended to be used with [`NoAdditionalStructure`](@ref), are [`AdditiveLyapunovNet`](@ref) and [`MultiplicativeLyapunovNet`](@ref).
+These each wrap a different Lux model, effectively performing the transformation from ``\phi`` to ``V`` within the Lux ecosystem, rather than in the NeuralPDE/ModelingToolkit symbolic ecosystem. 
+
+```@docs
+AdditiveLyapunovNet
+MultiplicativeLyapunovNet
+```
+
+Note that using [`NoAdditionalStructure`](@ref) with [`MultiplicativeLyapunovNet`](@ref) wrapping a Lux model ``\phi`` is the same as using [`PositiveSemiDefiniteStructure`](@ref) the same ``\phi``, but in the former the transformation is handled in the Lux ecosystem and in the latter the transformation is handled in the NeuralPDE/ModelingToolkit ecosystem.
+Similarly, using [`NonnegativeStructure`](@ref) with [`Boltz.Layers.ShiftTo`](https://luxdl.github.io/Boltz.jl/dev/api/layers#Boltz.Layers-API-Reference) is analogous to using [`NoAdditionalStructure`](@ref) with [`AdditiveLyapunovNet`](@ref).
+Because the NeuralPDE parser cannot process ``\phi`` being evaluated at two different points (in this case ``x`` and ``x_0``), we cannot represent this structure purely in the NeuralPDE/ModelingToolkit ecosystem.
+
+Helper layers provided for the above structures are also exported:
+
+```@docs
+SoSPooling
+StrictlyPositiveSoSPooling
+```
+
+## Defining your own neural Lyapunov function structure with [`NeuralLyapunovStructure`](@ref)
 
 To define a new structure for a neural Lyapunov function, one must specify the form of the Lyapunov candidate ``V`` and its time derivative along a trajectory ``\dot{V}``, as well as how to call the dynamics ``f``.
 Additionally, the dimensionality of the output of the neural network must be known in advance.

--- a/src/NeuralLyapunov.jl
+++ b/src/NeuralLyapunov.jl
@@ -16,6 +16,8 @@ using NeuralPDE: PhysicsInformedNN, discretize
 using OrdinaryDiffEq: Tsit5
 using EvalMetrics: ConfusionMatrix
 import LuxCore
+using Lux: Chain, Parallel, NoOpLayer, WrappedFunction
+using Boltz.Layers: ShiftTo
 using StableRNGs: StableRNG
 using QuasiMonteCarlo: sample, LatinHypercubeSample
 using Optimization: remake
@@ -30,10 +32,15 @@ include("numerical_lyapunov_functions.jl")
 include("local_lyapunov.jl")
 include("policy_search.jl")
 include("benchmark_harness.jl")
+include("lux_structures.jl")
 
 # Lyapunov function structures
 export NeuralLyapunovStructure, NoAdditionalStructure, NonnegativeStructure,
        PositiveSemiDefiniteStructure, get_numerical_lyapunov_function
+
+# Lux structures
+export AdditiveLyapunovNet, MultiplicativeLyapunovNet, SoSPooling,
+       StrictlyPositiveSoSPooling
 
 # Minimization conditions
 export LyapunovMinimizationCondition, StrictlyPositiveDefinite, PositiveSemiDefinite,

--- a/src/lux_structures.jl
+++ b/src/lux_structures.jl
@@ -13,35 +13,40 @@ term will be positive semidefinite.
 # Arguments
   - `ϕ`: The base neural network model; its output dimension should be `dim_ϕ`.
   - `ψ`: A Lux layer representing a positive semidefinite function that maps the output of
-    `ϕ` to a scalar value; defaults to `SoSPooling()` (i.e., ``\\lVert ⋅ \\rVert^2``). Users
-    may provide a function instead of a Lux layer, in which case it will be wrapped into a
-    layer via `WrappedFunction`.
+    `ϕ` to a scalar value; defaults to [`SoSPooling()`](@ref) (i.e.,
+    ``\\lVert ⋅ \\rVert^2``). Users may provide a function instead of a Lux layer, in which
+    case it will be wrapped into a layer via
+    [`Lux.WrappedFunction`](https://lux.csail.mit.edu/dev/api/Lux/layers#Misc.-Helper-Layers).
   - `m`: Optional pre-processing layer for use before `r`. This layer should output a vector
     of dimension `dim_m` and ``m(x) = m(x_0)`` should imply that ``x`` is an equilibrium to
-    be analyzed by the Lyapunov function. Defaults to `NoOpLayer()`, which is typically the
-    right choice when analyzing a single equilibrium point. Consider using a
-    `Boltz.Layers.PeriodicEmbedding` if any of the state variables are periodic. Users may
-    provide a function instead of a Lux layer, in which case it will be wrapped into a layer
-    via `WrappedFunction`.
+    be analyzed by the Lyapunov function. Defaults to
+    [`Lux.NoOpLayer()`](https://lux.csail.mit.edu/dev/api/Lux/layers#Misc.-Helper-Layers),
+    which is typically the right choice when analyzing a single equilibrium point. Consider
+    using a
+    [`Boltz.Layers.PeriodicEmbedding`](https://luxdl.github.io/Boltz.jl/dev/api/layers#Boltz.Layers-API-Reference)
+    if any of the state variables are periodic. Users may provide a function instead of a
+    Lux layer, in which case it will be wrapped into a layer via
+    [`Lux.WrappedFunction`](https://lux.csail.mit.edu/dev/api/Lux/layers#Misc.-Helper-Layers).
   - `r`: A Lux layer representing a positive definite function that maps the output of `m`
-    to a scalar value; defaults to `SoSPooling()` (i.e., ``\\lVert ⋅ \\rVert^2``). Users may
-    provide a function instead of a Lux layer, in which case it will be wrapped into a layer
-    via `WrappedFunction`.
+    to a scalar value; defaults to [`SoSPooling()`](@ref) (i.e., ``\\lVert ⋅ \\rVert^2``).
+    Users may provide a function instead of a Lux layer, in which case it will be wrapped
+    into a layer via
+    [`Lux.WrappedFunction`](https://lux.csail.mit.edu/dev/api/Lux/layers#Misc.-Helper-Layers).
   - `dim_ϕ`: The dimension of the output of `ϕ`.
   - `dim_m`: The dimension of the output of `m`; defaults to `length(fixed_point)` when
     `fixed_point` is provided and `dim_m` isn't. Users must provide at least one of `dim_m`
     and `fixed_point`.
-  - `fixed_point`: A vector in `ℝ^dim_m` representing the fixed point; defaults to
+  - `fixed_point`: A vector of length `dim_m` representing the fixed point; defaults to
     `zeros(dim_m)` when `dim_m` is provided and `fixed_point` isn't. Users must provide at
     least one of `dim_m` and `fixed_point`.
 """
 function AdditiveLyapunovNet(
-    ϕ;
-    ψ=SoSPooling(),
-    m=NoOpLayer(),
-    r=SoSPooling(),
-    dim_ϕ,
-    kwargs...
+        ϕ;
+        ψ = SoSPooling(),
+        m = NoOpLayer(),
+        r = SoSPooling(),
+        dim_ϕ,
+        kwargs...
 )
     if :dim_m in keys(kwargs)
         dim_m = kwargs[:dim_m]
@@ -102,31 +107,36 @@ term will be strictly positive.
 # Arguments
   - `ϕ`: The base neural network model.
   - `ζ`: A Lux layer representing a strictly positive function that maps the output of
-    `ϕ` to a scalar value; defaults to `StrictlyPositiveSoSPooling()` (i.e.,
+    `ϕ` to a scalar value; defaults to [`StrictlyPositiveSoSPooling()`](@ref) (i.e.,
     ``1 + \\lVert ⋅ \\rVert^2``). Users may provide a function instead of a Lux layer, in
-    which case it will be wrapped into a layer via `WrappedFunction`.
+    which case it will be wrapped into a layer via
+    [`Lux.WrappedFunction`](https://lux.csail.mit.edu/dev/api/Lux/layers#Misc.-Helper-Layers).
   - `m`: Optional pre-processing layer for use before `r`. This layer should output a vector
     of dimension `dim_m` and ``m(x) = m(x_0)`` should imply that ``x`` is an equilibrium to
-    be analyzed by the Lyapunov function. Defaults to `NoOpLayer()`, which is typically the
-    right choice when analyzing a single equilibrium point. Consider using a
-    `Boltz.Layers.PeriodicEmbedding` if any of the state variables are periodic. Users may
-    provide a function instead of a Lux layer, in which case it will be wrapped into a layer
-    via `WrappedFunction`.
+    be analyzed by the Lyapunov function. Defaults to
+    [`Lux.NoOpLayer()`](https://lux.csail.mit.edu/dev/api/Lux/layers#Misc.-Helper-Layers),
+    which is typically the right choice when analyzing a single equilibrium point. Consider
+    using a
+    [`Boltz.Layers.PeriodicEmbedding`](https://luxdl.github.io/Boltz.jl/dev/api/layers#Boltz.Layers-API-Reference)
+    if any of the state variables are periodic. Users may provide a function instead of a
+    Lux layer, in which case it will be wrapped into a layer via
+    [`Lux.WrappedFunction`](https://lux.csail.mit.edu/dev/api/Lux/layers#Misc.-Helper-Layers).
   - `r`: A Lux layer representing a positive definite function that maps the output of `m`
-    to a scalar value; defaults to `SoSPooling()` (i.e., ``\\lVert ⋅ \\rVert^2``). Users may
-    provide a function instead of a Lux layer, in which case it will be wrapped into a layer
-    via `WrappedFunction`.
+    to a scalar value; defaults to [`SoSPooling()`](@ref) (i.e., ``\\lVert ⋅ \\rVert^2``).
+    Users may provide a function instead of a Lux layer, in which case it will be wrapped
+    into a layer via
+    [`Lux.WrappedFunction`](https://lux.csail.mit.edu/dev/api/Lux/layers#Misc.-Helper-Layers).
   - `dim_m`: The dimension of the output of `m`; defaults to `length(fixed_point)` when
     `fixed_point` is provided and `dim_m` isn't.
-  - `fixed_point`: A vector in `ℝ^dim_m` representing the fixed point; defaults to
+  - `fixed_point`: A vector of length `dim_m` representing the fixed point; defaults to
     `zeros(dim_m)` when `dim_m` is provided and `fixed_point` isn't.
 """
 function MultiplicativeLyapunovNet(
-    ϕ;
-    ζ=StrictlyPositiveSoSPooling(),
-    m=NoOpLayer(),
-    r=SoSPooling(),
-    kwargs...
+        ϕ;
+        ζ = StrictlyPositiveSoSPooling(),
+        m = NoOpLayer(),
+        r  =SoSPooling(),
+        kwargs...
 )
     if :dim_m in keys(kwargs)
         dim_m = kwargs[:dim_m]
@@ -154,7 +164,7 @@ function MultiplicativeLyapunovNet(
 
     return Parallel(
         .*,
-        Chain(ϕ,ζ),
+        Chain(ϕ, ζ),
         Chain(
             ShiftTo(
                 m,

--- a/src/lux_structures.jl
+++ b/src/lux_structures.jl
@@ -135,7 +135,7 @@ function MultiplicativeLyapunovNet(
         ϕ;
         ζ = StrictlyPositiveSoSPooling(),
         m = NoOpLayer(),
-        r  =SoSPooling(),
+        r = SoSPooling(),
         kwargs...
 )
     if :dim_m in keys(kwargs)

--- a/src/lux_structures.jl
+++ b/src/lux_structures.jl
@@ -1,0 +1,183 @@
+"""
+    AdditiveLyapunovNet(ϕ; ψ, m, r, dim_ϕ, dim_m, fixed_point)
+
+Construct a Lyapunov-Net with the following structure:
+```math
+    V(x) = ψ(ϕ(x) - ϕ(x_0)) + r(m(x) - m(x_0)),
+```
+where ``x_0`` is `fixed_point` and the functions are defined as below.
+If the functions meet the conditions listed below, the resulting model will be positive
+definite (around `fixed_point`), as the ``r`` term will be positive definite and the ``ψ``
+term will be positive semidefinite.
+
+# Arguments
+  - `ϕ`: The base neural network model; its output dimension should be `dim_ϕ`.
+  - `ψ`: A Lux layer representing a positive semidefinite function that maps the output of
+    `ϕ` to a scalar value; defaults to `SoSPooling()` (i.e., ``\\lVert ⋅ \\rVert^2``). Users
+    may provide a function instead of a Lux layer, in which case it will be wrapped into a
+    layer via `WrappedFunction`.
+  - `m`: Optional pre-processing layer for use before `r`. This layer should output a vector
+    of dimension `dim_m` and ``m(x) = m(x_0)`` should imply that ``x`` is an equilibrium to
+    be analyzed by the Lyapunov function. Defaults to `NoOpLayer()`, which is typically the
+    right choice when analyzing a single equilibrium point. Consider using a
+    `Boltz.Layers.PeriodicEmbedding` if any of the state variables are periodic. Users may
+    provide a function instead of a Lux layer, in which case it will be wrapped into a layer
+    via `WrappedFunction`.
+  - `r`: A Lux layer representing a positive definite function that maps the output of `m`
+    to a scalar value; defaults to `SoSPooling()` (i.e., ``\\lVert ⋅ \\rVert^2``). Users may
+    provide a function instead of a Lux layer, in which case it will be wrapped into a layer
+    via `WrappedFunction`.
+  - `dim_ϕ`: The dimension of the output of `ϕ`.
+  - `dim_m`: The dimension of the output of `m`; defaults to `length(fixed_point)` when
+    `fixed_point` is provided and `dim_m` isn't. Users must provide at least one of `dim_m`
+    and `fixed_point`.
+  - `fixed_point`: A vector in `ℝ^dim_m` representing the fixed point; defaults to
+    `zeros(dim_m)` when `dim_m` is provided and `fixed_point` isn't. Users must provide at
+    least one of `dim_m` and `fixed_point`.
+"""
+function AdditiveLyapunovNet(
+    ϕ;
+    ψ=SoSPooling(),
+    m=NoOpLayer(),
+    r=SoSPooling(),
+    dim_ϕ,
+    kwargs...
+)
+    if :dim_m in keys(kwargs)
+        dim_m = kwargs[:dim_m]
+        if :fixed_point in keys(kwargs)
+            fixed_point = kwargs[:fixed_point]
+        else
+            fixed_point = zeros(dim_m)
+        end
+    elseif :fixed_point in keys(kwargs)
+        fixed_point = kwargs[:fixed_point]
+        dim_m = length(fixed_point)
+    else
+        throw(ArgumentError("Either `dim_m` or `fixed_point` must be provided."))
+    end
+
+    if ψ isa Function
+        ψ = WrappedFunction(ψ)
+    end
+    if m isa Function
+        m = WrappedFunction(m)
+    end
+    if r isa Function
+        r = WrappedFunction(r)
+    end
+
+    return Parallel(
+        +,
+        Chain(
+            ShiftTo(
+                ϕ,
+                fixed_point,
+                zeros(eltype(fixed_point), dim_ϕ)
+            ),
+            ψ
+        ),
+        Chain(
+            ShiftTo(
+                m,
+                fixed_point,
+                zeros(eltype(fixed_point), dim_m)
+            ),
+            r
+        )
+    )
+end
+
+"""
+    MultiplicativeLyapunovNet(ϕ; ζ, m, r, dim_m, fixed_point)
+Construct a Lyapunov-Net with the following structure:
+```math
+    V(x) = ζ(ϕ(x)) (r(m(x) - m(x_0))),
+```
+where ``x_0`` is `fixed_point` and the functions are defined as below.
+If the functions meet the conditions listed below, the resulting model will be positive
+definite (around `fixed_point`), as the ``r`` term will be positive definite and the ``ζ``
+term will be strictly positive.
+
+# Arguments
+  - `ϕ`: The base neural network model.
+  - `ζ`: A Lux layer representing a strictly positive function that maps the output of
+    `ϕ` to a scalar value; defaults to `StrictlyPositiveSoSPooling()` (i.e.,
+    ``1 + \\lVert ⋅ \\rVert^2``). Users may provide a function instead of a Lux layer, in
+    which case it will be wrapped into a layer via `WrappedFunction`.
+  - `m`: Optional pre-processing layer for use before `r`. This layer should output a vector
+    of dimension `dim_m` and ``m(x) = m(x_0)`` should imply that ``x`` is an equilibrium to
+    be analyzed by the Lyapunov function. Defaults to `NoOpLayer()`, which is typically the
+    right choice when analyzing a single equilibrium point. Consider using a
+    `Boltz.Layers.PeriodicEmbedding` if any of the state variables are periodic. Users may
+    provide a function instead of a Lux layer, in which case it will be wrapped into a layer
+    via `WrappedFunction`.
+  - `r`: A Lux layer representing a positive definite function that maps the output of `m`
+    to a scalar value; defaults to `SoSPooling()` (i.e., ``\\lVert ⋅ \\rVert^2``). Users may
+    provide a function instead of a Lux layer, in which case it will be wrapped into a layer
+    via `WrappedFunction`.
+  - `dim_m`: The dimension of the output of `m`; defaults to `length(fixed_point)` when
+    `fixed_point` is provided and `dim_m` isn't.
+  - `fixed_point`: A vector in `ℝ^dim_m` representing the fixed point; defaults to
+    `zeros(dim_m)` when `dim_m` is provided and `fixed_point` isn't.
+"""
+function MultiplicativeLyapunovNet(
+    ϕ;
+    ζ=StrictlyPositiveSoSPooling(),
+    m=NoOpLayer(),
+    r=SoSPooling(),
+    kwargs...
+)
+    if :dim_m in keys(kwargs)
+        dim_m = kwargs[:dim_m]
+        if :fixed_point in keys(kwargs)
+            fixed_point = kwargs[:fixed_point]
+        else
+            fixed_point = zeros(dim_m)
+        end
+    elseif :fixed_point in keys(kwargs)
+        fixed_point = kwargs[:fixed_point]
+        dim_m = length(fixed_point)
+    else
+        throw(ArgumentError("Either `dim_m` or `fixed_point` must be provided."))
+    end
+
+    if ζ isa Function
+        ζ = WrappedFunction(ζ)
+    end
+    if m isa Function
+        m = WrappedFunction(m)
+    end
+    if r isa Function
+        r = WrappedFunction(r)
+    end
+
+    return Parallel(
+        .*,
+        Chain(ϕ,ζ),
+        Chain(
+            ShiftTo(
+                m,
+                fixed_point,
+                zeros(eltype(fixed_point), dim_m)
+            ),
+            r
+        )
+    )
+end
+
+"""
+    SoSPooling(; dim = 1)
+
+Construct a pooling function that computes the sum of squares along the dimension `dim`.
+"""
+SoSPooling(; dim = 1) = WrappedFunction(x -> sum(abs2, x, dims = dim))
+
+"""
+    StrictlyPositiveSoSPooling(; dim = 1)
+
+Construct a pooling function that computes 1 + the sum of squares along the dimension `dim`.
+"""
+function StrictlyPositiveSoSPooling(; dim = 1)
+    return WrappedFunction(x -> one(eltype(x)) .+ sum(abs2, x, dims = dim))
+end

--- a/test/damped_pendulum_lux.jl
+++ b/test/damped_pendulum_lux.jl
@@ -1,0 +1,201 @@
+using NeuralPDE, Lux, ModelingToolkit, NeuralLyapunov
+import Boltz.Layers: PeriodicEmbedding, MLP
+import Optimization, OptimizationOptimisers, OptimizationOptimJL
+using StableRNGs, Random
+using Test, LinearAlgebra, ForwardDiff
+
+rng = StableRNG(0)
+Random.seed!(200)
+
+println("Damped Pendulum - AdditiveLyapunovNet structure")
+
+######################### Define dynamics and domain ##########################
+
+@parameters ζ ω_0
+defaults = Dict([ζ => 0.5, ω_0 => 1.0])
+
+@independent_variables t
+@variables θ(t)
+Dt = Differential(t)
+DDt = Dt^2
+
+eqs = [DDt(θ) + 2ζ * ω_0 * Dt(θ) + ω_0^2 * sin(θ) ~ 0.0]
+
+@named dynamics = ODESystem(
+    eqs,
+    t,
+    [θ],
+    [ζ, ω_0];
+    defaults
+)
+
+dynamics = structural_simplify(dynamics)
+bounds = [
+    θ ∈ (-π, π),
+    Dt(θ) ∈ (-10.0, 10.0)
+]
+lb = [-π, -10.0];
+ub = [π, 10.0];
+p = [defaults[param] for param in parameters(dynamics)]
+fixed_point = [0.0, 0.0]
+
+####################### Specify neural Lyapunov problem #######################
+
+# Define neural network discretization
+# We use a LyapunovNet with an input layer that is periodic with period 2π with
+# respect to θ
+dim_state = length(bounds)
+dim_hidden = 15
+dim_output = 2
+periodic_embedding_layer = PeriodicEmbedding([1], [2π])
+ps, st = Lux.setup(rng, periodic_embedding_layer)
+periodic_embedding(x) = first(periodic_embedding_layer(x, ps, st))
+fixed_point_embedded = periodic_embedding(fixed_point)
+chain = Chain(
+    periodic_embedding_layer,
+    AdditiveLyapunovNet(
+        MLP(dim_state + 1, (dim_hidden, dim_hidden, dim_output), tanh);
+        dim_ϕ = dim_output,
+        dim_m = dim_state + 1,
+        fixed_point = fixed_point_embedded
+    ),
+)
+ps = Lux.initialparameters(rng, chain)
+
+# Define neural network discretization
+strategy = QuasiRandomTraining(1000)
+discretization = PhysicsInformedNN(chain, strategy; init_params = ps)
+
+# Define neural Lyapunov structure
+structure = NoAdditionalStructure()
+minimization_condition = DontCheckNonnegativity(check_fixed_point = false)
+
+# Define Lyapunov decrease condition
+decrease_condition = AsymptoticStability(
+    strength = (x, x0) -> sum(abs2, periodic_embedding(x) .- periodic_embedding(x0))
+)
+
+# Construct neural Lyapunov specification
+spec = NeuralLyapunovSpecification(
+    structure,
+    minimization_condition,
+    decrease_condition
+)
+
+############################# Construct PDESystem #############################
+
+@named pde_system = NeuralLyapunovPDESystem(
+    ODEFunction(dynamics),
+    lb,
+    ub,
+    spec;
+    p
+)
+
+######################## Construct OptimizationProblem ########################
+
+sym_prob = symbolic_discretize(pde_system, discretization)
+prob = discretize(pde_system, discretization)
+
+########################## Solve OptimizationProblem ##########################
+
+res = Optimization.solve(prob, OptimizationOptimisers.Adam(0.01); maxiters = 300)
+prob = Optimization.remake(prob, u0 = res.u)
+res = Optimization.solve(prob, OptimizationOptimJL.BFGS(); maxiters = 300)
+
+###################### Get numerical numerical functions ######################
+
+V, V̇ = get_numerical_lyapunov_function(
+    discretization.phi,
+    res.u,
+    structure,
+    ODEFunction(dynamics),
+    zeros(length(bounds));
+    p = p
+)
+
+################################## Simulate ###################################
+
+xs = (2 * lb[1]):0.02:(2 * ub[1])
+ys = lb[2]:0.02:ub[2]
+states = Iterators.map(collect, Iterators.product(xs, ys))
+V_predict = vec(V(hcat(states...)))
+dVdt_predict = vec(V̇(hcat(states...)))
+
+#################################### Tests ####################################
+
+# Network structure should enforce positive definiteness
+V0 = V(fixed_point)[]
+@test V0 == 0.0
+@test min(V0, minimum(V_predict)) ≥ 0.0
+
+# Check local positive definiteness at fixed point
+@test maximum(abs, ForwardDiff.gradient(first ∘ V, fixed_point)) ≤ 1e-10
+@test minimum(eigvals(ForwardDiff.hessian(first ∘ V, fixed_point))) .≥ 0
+
+# Network structure should enforce periodicity in θ
+x0 = (ub .- lb) .* rand(rng, 2, 100) .+ lb
+@test maximum(abs, V(x0 .+ [2π, 0.0]) .- V(x0)) .≤ 1e-3
+
+# Check local negative definiteness at fixed point
+@test V̇(fixed_point)[] == 0.0
+@test maximum(abs, ForwardDiff.gradient(first ∘ V̇, fixed_point)) ≤ 1e-10
+@test maximum(eigvals(ForwardDiff.hessian(first ∘ V̇, fixed_point))) ≤ 0
+
+# V̇ should be negative almost everywhere (global negative definiteness)
+@test sum(dVdt_predict .> 0) / length(dVdt_predict) < 1e-3
+
+#=
+# Print statistics
+println("V(0.,0.) = ", V(fixed_point)[])
+println("V ∋ [", min(V(fixed_point)[], minimum(V_predict)), ", ", maximum(V_predict), "]")
+println(
+    "V̇ ∋ [",
+    minimum(dVdt_predict),
+    ", ",
+    max(V̇(fixed_point)[], maximum(dVdt_predict)),
+    "]",
+)
+
+# Plot results
+using Plots
+
+p1 = plot(
+    xs/pi,
+    ys,
+    V_predict,
+    linetype = :contourf,
+    title = "V",
+    xlabel = "θ/π",
+    ylabel = "ω",
+    c = :bone_1
+    );
+p1 = scatter!([-2*pi, 0, 2*pi]/pi, [0, 0, 0], label = "Stable Equilibria", color=:green, markershape=:+);
+p1 = scatter!([-pi, pi]/pi, [0, 0], label = "Unstable Equilibria", color=:red, markershape=:x);
+p2 = plot(
+    xs/pi,
+    ys,
+    dVdt_predict,
+    linetype = :contourf,
+    title = "dV/dt",
+    xlabel = "θ/π",
+    ylabel = "ω",
+    c = :binary
+);
+p2 = scatter!([-2*pi, 0, 2*pi]/pi, [0, 0, 0], label = "Stable Equilibria", color=:green, markershape=:+);
+p2 = scatter!([-pi, pi]/pi, [0, 0], label = "Unstable Equilibria", color=:red, markershape=:x, legend=false);
+p3 = plot(
+    xs/pi,
+    ys,
+    dVdt_predict .< 0,
+    linetype = :contourf,
+    title = "dV/dt < 0",
+    xlabel = "θ/π",
+    ylabel = "ω",
+    colorbar = false,
+    linewidth = 0
+);
+p3 = scatter!([-2*pi, 0, 2*pi]/pi, [0, 0, 0], label = "Stable Equilibria", color=:green, markershape=:+);
+p3 = scatter!([-pi, pi]/pi, [0, 0], label = "Unstable Equilibria", color=:red, markershape=:x, legend=false);
+plot(p1, p2, p3)
+=#

--- a/test/damped_pendulum_lux.jl
+++ b/test/damped_pendulum_lux.jl
@@ -58,7 +58,7 @@ chain = Chain(
         dim_ϕ = dim_output,
         dim_m = dim_state + 1,
         fixed_point = fixed_point_embedded
-    ),
+    )
 )
 ps = Lux.initialparameters(rng, chain)
 

--- a/test/damped_pendulum_lux_2.jl
+++ b/test/damped_pendulum_lux_2.jl
@@ -57,7 +57,7 @@ chain = Chain(
         MLP(dim_state + 1, (dim_hidden, dim_hidden, dim_output), tanh);
         dim_m = dim_state + 1,
         fixed_point = fixed_point_embedded
-    ),
+    )
 )
 ps = Lux.initialparameters(rng, chain)
 

--- a/test/damped_pendulum_lux_2.jl
+++ b/test/damped_pendulum_lux_2.jl
@@ -1,0 +1,200 @@
+using NeuralPDE, Lux, ModelingToolkit, NeuralLyapunov
+import Boltz.Layers: PeriodicEmbedding, MLP
+import Optimization, OptimizationOptimisers, OptimizationOptimJL
+using StableRNGs, Random
+using Test, LinearAlgebra, ForwardDiff
+
+rng = StableRNG(0)
+Random.seed!(200)
+
+println("Damped Pendulum - MultiplicativeLyapunovNet structure")
+
+######################### Define dynamics and domain ##########################
+
+@parameters ζ ω_0
+defaults = Dict([ζ => 0.5, ω_0 => 1.0])
+
+@independent_variables t
+@variables θ(t)
+Dt = Differential(t)
+DDt = Dt^2
+
+eqs = [DDt(θ) + 2ζ * ω_0 * Dt(θ) + ω_0^2 * sin(θ) ~ 0.0]
+
+@named dynamics = ODESystem(
+    eqs,
+    t,
+    [θ],
+    [ζ, ω_0];
+    defaults
+)
+
+dynamics = structural_simplify(dynamics)
+bounds = [
+    θ ∈ (-π, π),
+    Dt(θ) ∈ (-10.0, 10.0)
+]
+lb = [-π, -10.0];
+ub = [π, 10.0];
+p = [defaults[param] for param in parameters(dynamics)]
+fixed_point = [0.0, 0.0]
+
+####################### Specify neural Lyapunov problem #######################
+
+# Define neural network discretization
+# We use a LyapunovNet with an input layer that is periodic with period 2π with
+# respect to θ
+dim_state = length(bounds)
+dim_hidden = 15
+dim_output = 2
+periodic_embedding_layer = PeriodicEmbedding([1], [2π])
+ps, st = Lux.setup(rng, periodic_embedding_layer)
+periodic_embedding(x) = first(periodic_embedding_layer(x, ps, st))
+fixed_point_embedded = periodic_embedding(fixed_point)
+chain = Chain(
+    periodic_embedding_layer,
+    MultiplicativeLyapunovNet(
+        MLP(dim_state + 1, (dim_hidden, dim_hidden, dim_output), tanh);
+        dim_m = dim_state + 1,
+        fixed_point = fixed_point_embedded
+    ),
+)
+ps = Lux.initialparameters(rng, chain)
+
+# Define neural network discretization
+strategy = QuasiRandomTraining(1000)
+discretization = PhysicsInformedNN(chain, strategy; init_params = ps)
+
+# Define neural Lyapunov structure
+structure = NoAdditionalStructure()
+minimization_condition = DontCheckNonnegativity(check_fixed_point = false)
+
+# Define Lyapunov decrease condition
+decrease_condition = AsymptoticStability(
+    strength = (x, x0) -> sum(abs2, periodic_embedding(x) .- periodic_embedding(x0))
+)
+
+# Construct neural Lyapunov specification
+spec = NeuralLyapunovSpecification(
+    structure,
+    minimization_condition,
+    decrease_condition
+)
+
+############################# Construct PDESystem #############################
+
+@named pde_system = NeuralLyapunovPDESystem(
+    ODEFunction(dynamics),
+    lb,
+    ub,
+    spec;
+    p
+)
+
+######################## Construct OptimizationProblem ########################
+
+sym_prob = symbolic_discretize(pde_system, discretization)
+prob = discretize(pde_system, discretization)
+
+########################## Solve OptimizationProblem ##########################
+
+res = Optimization.solve(prob, OptimizationOptimisers.Adam(0.01); maxiters = 300)
+prob = Optimization.remake(prob, u0 = res.u)
+res = Optimization.solve(prob, OptimizationOptimJL.BFGS(); maxiters = 300)
+
+###################### Get numerical numerical functions ######################
+
+V, V̇ = get_numerical_lyapunov_function(
+    discretization.phi,
+    res.u,
+    structure,
+    ODEFunction(dynamics),
+    zeros(length(bounds));
+    p = p
+)
+
+################################## Simulate ###################################
+
+xs = (2 * lb[1]):0.02:(2 * ub[1])
+ys = lb[2]:0.02:ub[2]
+states = Iterators.map(collect, Iterators.product(xs, ys))
+V_predict = vec(V(hcat(states...)))
+dVdt_predict = vec(V̇(hcat(states...)))
+
+#################################### Tests ####################################
+
+# Network structure should enforce positive definiteness
+V0 = V(fixed_point)[]
+@test V0 == 0.0
+@test min(V0, minimum(V_predict)) ≥ 0.0
+
+# Check local positive definiteness at fixed point
+@test maximum(abs, ForwardDiff.gradient(first ∘ V, fixed_point)) ≤ 1e-10
+@test minimum(eigvals(ForwardDiff.hessian(first ∘ V, fixed_point))) .≥ 0
+
+# Network structure should enforce periodicity in θ
+x0 = (ub .- lb) .* rand(rng, 2, 100) .+ lb
+@test maximum(abs, V(x0 .+ [2π, 0.0]) .- V(x0)) .≤ 1e-3
+
+# Check local negative definiteness at fixed point
+@test V̇(fixed_point)[] == 0.0
+@test maximum(abs, ForwardDiff.gradient(first ∘ V̇, fixed_point)) ≤ 1e-10
+@test maximum(eigvals(ForwardDiff.hessian(first ∘ V̇, fixed_point))) ≤ 0
+
+# V̇ should be negative almost everywhere (global negative definiteness)
+@test sum(dVdt_predict .> 0) / length(dVdt_predict) < 3e-3
+
+#=
+# Print statistics
+println("V(0.,0.) = ", V(fixed_point)[])
+println("V ∋ [", min(V(fixed_point)[], minimum(V_predict)), ", ", maximum(V_predict), "]")
+println(
+    "V̇ ∋ [",
+    minimum(dVdt_predict),
+    ", ",
+    max(V̇(fixed_point)[], maximum(dVdt_predict)),
+    "]",
+)
+
+# Plot results
+using Plots
+
+p1 = plot(
+    xs/pi,
+    ys,
+    V_predict,
+    linetype = :contourf,
+    title = "V",
+    xlabel = "θ/π",
+    ylabel = "ω",
+    c = :bone_1
+    );
+p1 = scatter!([-2*pi, 0, 2*pi]/pi, [0, 0, 0], label = "Stable Equilibria", color=:green, markershape=:+);
+p1 = scatter!([-pi, pi]/pi, [0, 0], label = "Unstable Equilibria", color=:red, markershape=:x);
+p2 = plot(
+    xs/pi,
+    ys,
+    log.(abs.(dVdt_predict)),
+    linetype = :contourf,
+    title = "dV/dt",
+    xlabel = "θ/π",
+    ylabel = "ω",
+    c = :binary
+);
+p2 = scatter!([-2*pi, 0, 2*pi]/pi, [0, 0, 0], label = "Stable Equilibria", color=:green, markershape=:+);
+p2 = scatter!([-pi, pi]/pi, [0, 0], label = "Unstable Equilibria", color=:red, markershape=:x, legend=false);
+p3 = plot(
+    xs/pi,
+    ys,
+    dVdt_predict .< 0,
+    linetype = :contourf,
+    title = "dV/dt < 0",
+    xlabel = "θ/π",
+    ylabel = "ω",
+    colorbar = false,
+    linewidth = 0
+);
+p3 = scatter!([-2*pi, 0, 2*pi]/pi, [0, 0, 0], label = "Stable Equilibria", color=:green, markershape=:+);
+p3 = scatter!([-pi, pi]/pi, [0, 0], label = "Unstable Equilibria", color=:red, markershape=:x, legend=false);
+plot(p1, p2, p3)
+=#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,12 @@ const DEVICE = lowercase(get(ENV, "DEVICE", "cpu"))
             @time @safetestset "Damped pendulum" begin
                 include("damped_pendulum.jl")
             end
+            @time @safetestset "Damped pendulum - AdditiveLyapunovNet structure" begin
+                include("damped_pendulum_lux.jl")
+            end
+            @time @safetestset "Damped pendulum - MultiplicativeLyapunovNet structure" begin
+                include("damped_pendulum_lux_2.jl")
+            end
         end
 
         if DEVICE == "gpu"


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

These are Lux/Boltz implementations of LyapunovNet Gaby et al 2021 and a multiplicative version of the same idea.