### PR TITLE
Fix `benchmark` mass matrix problem

### DIFF
--- a/src/benchmark_harness.jl
+++ b/src/benchmark_harness.jl
@@ -139,7 +139,9 @@ function benchmark(
     f = if isempty(unbound_inputs(dynamics))
         ODEFunction(dynamics)
     else
-        ODEInputFunction(dynamics; simplify = true, split = false)
+        dynamics_io_sys, _ = structural_simplify(
+            dynamics, (unbound_inputs(dynamics), []); split = false)
+        ODEInputFunction(dynamics_io_sys; simplify = true, split = false)
     end
 
     defs = defaults(dynamics)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

`benchmark` was throwing an error at times when getting the `ODEInputFunction` since the system had not yet been simplified.