### PR TITLE
Update CI workflows for downgrade v2 (issue #1076)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,12 +55,13 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-      - uses: julia-actions/julia-downgrade-compat@v1
+      - uses: julia-actions/julia-downgrade-compat@v2
         with:
           projects: ${{matrix.project}}
           skip: LinearAlgebra, Pkg, Random, Test
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+          ALLOW_RERESOLVE: false
         with:
           project: ${{ matrix.project }}
         env:


### PR DESCRIPTION
## Summary
- Updates julia-downgrade-compat from @v1 to @v2
- Adds ALLOW_RERESOLVE: false to julia-runtest steps in downgrade jobs
- Addresses requirements from SciMLBase.jl issue #1076

## Changes Made
- Updated 1 CI workflow file(s)
- Ensures compatibility with downgrade v2 requirements
- Maintains existing test configurations and skip parameters

## Test plan
- [ ] Verify CI workflows continue to work with updated downgrade action
- [ ] Confirm ALLOW_RERESOLVE: false prevents re-resolution as intended
- [ ] Check that existing test groups and configurations are preserved

Fixes SciML/SciMLBase.jl#1076

🤖 Generated with [Claude Code](https://claude.ai/code)