### PR TITLE
Remove references to `Function`

### DIFF
--- a/docs/src/demos/damped_SHO.md
+++ b/docs/src/demos/damped_SHO.md
@@ -80,7 +80,7 @@ spec = NeuralLyapunovSpecification(
     lb,
     ub,
     spec;
-    p = p
+    p
 )
 
 ######################## Construct OptimizationProblem ########################
@@ -101,7 +101,7 @@ V, V̇ = get_numerical_lyapunov_function(
     structure,
     f,
     fixed_point;
-    p = p
+    p
 )
 ```
 
@@ -202,7 +202,7 @@ spec = NeuralLyapunovSpecification(
     lb,
     ub,
     spec;
-    p = p
+    p
 )
 ```
 
@@ -228,7 +228,7 @@ V, V̇ = get_numerical_lyapunov_function(
     structure,
     f,
     fixed_point;
-    p = p
+    p
 )
 nothing # hide
 ```

--- a/docs/src/demos/policy_search.md
+++ b/docs/src/demos/policy_search.md
@@ -282,7 +282,7 @@ V_func, V̇_func = get_numerical_lyapunov_function(
     structure,
     open_loop_pendulum_dynamics,
     upright_equilibrium;
-    p = p
+    p
 )
 
 u = get_policy(net, _θ, dim_output, dim_u)

--- a/docs/src/man/structure.md
+++ b/docs/src/man/structure.md
@@ -70,7 +70,7 @@ NeuralLyapunovStructure
 ### Calling the dynamics
 
 Very generally, the dynamical system can be a system of ODEs ``\dot{x} = f(x, u, p, t)``, where ``u`` is a control input, ``p`` contains parameters, and ``f`` depends on the neural network in some way.
-To capture this variety, users must supply the function `f_call(dynamics::Function, phi::Function, state, p, t)`.
+To capture this variety, users must supply the function `f_call(dynamics, phi, state, p, t)`.
 
 The most common example is when `dynamics` takes the same form as an `ODEFunction`. 
 i.e., ``\dot{x} = \texttt{dynamics}(x, p, t)``.

--- a/lib/NeuralLyapunovProblemLibrary/ext/NeuralLyapunovProblemLibraryPlotsExt/pendulum_plot.jl
+++ b/lib/NeuralLyapunovProblemLibrary/ext/NeuralLyapunovProblemLibraryPlotsExt/pendulum_plot.jl
@@ -19,7 +19,7 @@ function NeuralLyapunovProblemLibrary.plot_pendulum(
         sol; title = "", N = 500, angle_symbol = :θ)
     t = LinRange(sol.t[1], sol.t[end], N)
     θ = sol(t)[angle_symbol]
-    return plot_pendulum(θ, t; title = title)
+    return plot_pendulum(θ, t; title)
 end
 
 function NeuralLyapunovProblemLibrary.plot_pendulum(θ, t; title = "")

--- a/lib/NeuralLyapunovProblemLibrary/src/double_pendulum.jl
+++ b/lib/NeuralLyapunovProblemLibrary/src/double_pendulum.jl
@@ -61,9 +61,9 @@ function DoublePendulum(; actuation = :fully_actuated, name, defaults = NullPara
     params = [I1, I2, l1, l2, lc1, lc2, m1, m2, g]
 
     kwargs = if defaults == NullParameters()
-        (; name = name)
+        (; name)
     else
-        (; name = name, defaults = Dict(params .=> defaults))
+        (; name, defaults = Dict(params .=> defaults))
     end
 
     if actuation == :fully_actuated

--- a/lib/NeuralLyapunovProblemLibrary/src/pendulum.jl
+++ b/lib/NeuralLyapunovProblemLibrary/src/pendulum.jl
@@ -48,9 +48,9 @@ function Pendulum(; driven = true, name, defaults = NullParameters())
 
     params = [ζ, ω_0]
     kwargs = if defaults == NullParameters()
-        (; name = name)
+        (; name)
     else
-        (; name = name, defaults = Dict(params .=> defaults))
+        (; name, defaults = Dict(params .=> defaults))
     end
 
     torque = if driven

--- a/lib/NeuralLyapunovProblemLibrary/src/quadrotor.jl
+++ b/lib/NeuralLyapunovProblemLibrary/src/quadrotor.jl
@@ -53,9 +53,9 @@ function QuadrotorPlanar(; name, defaults = NullParameters())
 
     params = [m, I_quad, g, r]
     kwargs = if defaults == NullParameters()
-        (; name = name)
+        (; name)
     else
-        (; name = name, defaults = Dict(params .=> defaults))
+        (; name, defaults = Dict(params .=> defaults))
     end
 
     return ODESystem(eqs, t, [x, y, θ, u1, u2], params; kwargs...)
@@ -164,9 +164,9 @@ function Quadrotor3D(; name, defaults = NullParameters())
     )
 
     kwargs = if defaults == NullParameters()
-        (; name = name)
+        (; name)
     else
-        (; name = name, defaults = Dict(params .=> defaults))
+        (; name, defaults = Dict(params .=> defaults))
     end
 
     return ODESystem(

--- a/lib/NeuralLyapunovProblemLibrary/src/quadrotor.jl
+++ b/lib/NeuralLyapunovProblemLibrary/src/quadrotor.jl
@@ -134,7 +134,7 @@ function Quadrotor3D(; name, defaults = NullParameters())
 
     # Angular velocity (world frame)
     @variables ωφ(t), ωθ(t), ωψ(t)
-    angular_velocity_world = [ωφ, ωθ, ωψ]
+    ω_world = [ωφ, ωθ, ωψ]
 
     # Inputs
     # T-thrust, τφ-roll torque, τθ-pitch torque, τψ-yaw torque
@@ -159,12 +159,8 @@ function Quadrotor3D(; name, defaults = NullParameters())
     eqs = vcat(
         Dt.(position_world) .~ velocity_world,
         Dt.(velocity_world) .~ F ./ m .+ g_vec,
-        Dt.(attitude) .~ inv(R) * angular_velocity_world,
-        Dt.(angular_velocity_world) .~
-        inertia_matrix \
-        (τ -
-         angular_velocity_world ×
-         (inertia_matrix * angular_velocity_world))
+        Dt.(attitude) .~ inv(R) * ω_world,
+        Dt.(ω_world) .~ inertia_matrix \ (τ - ω_world × (inertia_matrix * ω_world))
     )
 
     kwargs = if defaults == NullParameters()
@@ -176,8 +172,7 @@ function Quadrotor3D(; name, defaults = NullParameters())
     return ODESystem(
         eqs,
         t,
-        vcat(position_world, attitude, velocity_world,
-            angular_velocity_world, T, τφ, τθ, τψ),
+        vcat(position_world, attitude, velocity_world, ω_world, T, τφ, τθ, τψ),
         params;
         kwargs...
     )

--- a/src/NeuralLyapunovPDESystem.jl
+++ b/src/NeuralLyapunovPDESystem.jl
@@ -108,7 +108,7 @@ function NeuralLyapunovPDESystem(
         p = SciMLBase.NullParameters(),
         state_syms = [],
         parameter_syms = [],
-        policy_search::Bool = typeof(dynamics) <: ODEInputFunction,
+        policy_search::Bool = dynamics isa ODEInputFunction,
         name
 )::PDESystem
     if dynamics.mass_matrix !== I

--- a/src/NeuralLyapunovPDESystem.jl
+++ b/src/NeuralLyapunovPDESystem.jl
@@ -1,6 +1,6 @@
 """
     NeuralLyapunovPDESystem(dynamics::ODESystem, bounds, spec; <keyword_arguments>)
-    NeuralLyapunovPDESystem(dynamics::Function, lb, ub, spec; <keyword_arguments>)
+    NeuralLyapunovPDESystem(dynamics, lb, ub, spec; <keyword_arguments>)
 
 Construct a `ModelingToolkit.PDESystem` representing the specified neural Lyapunov problem.
 
@@ -23,22 +23,23 @@ Construct a `ModelingToolkit.PDESystem` representing the specified neural Lyapun
     `SciMLBase.NullParameters()`; not used when `dynamics isa ODESystem`, then use the
     default parameter values of `dynamics`.
   - `state_syms`: an array of the `Symbol` representing each state; not used when `dynamics
-    isa ODESystem`, then the symbols from `dynamics` are used; if `dynamics isa ODEFunction`,
-    symbols stored there are used, unless overridden here; if not provided here and cannot
-    be inferred, `[:state1, :state2, ...]` will be used.
+    isa ODESystem` (in that case, the symbols from `dynamics` are used); if `dynamics` is an
+    `ODEFunction` or an `ODEInputFunction`, the symbols stored there are used, unless
+    overridden here; if not provided here and cannot be inferred, `[:state1, :state2, ...]`
+    will be used.
   - `parameter_syms`: an array of the `Symbol` representing each parameter; not used when
-    `dynamics isa ODESystem`, then the symbols from `dynamics` are used; if `dynamics isa
-    ODEFunction`, symbols stored there are used, unless overridden here; if not provided
-    here and cannot be inferred, `[:param1, :param2, ...]` will be used.
+    `dynamics isa ODESystem` (in that case, the symbols from `dynamics` are used); if
+    `dynamics` is an `ODEFunction` or an `ODEInputFunction`, the symbols stored there are
+    used, unless overridden here; if not provided here and cannot be inferred,
+    `[:param1, :param2, ...]` will be used.
   - `policy_search::Bool`: whether or not to include a loss term enforcing `fixed_point` to
-    actually be a fixed point; defaults to `false`; only used when `dynamics isa Function &&
-    !(dynamics isa ODEFunction)`; when `dynamics isa ODEFunction`, `policy_search` should
-    not be supplied (as it must be false); when `dynamics isa ODESystem`, value inferred by
-    the presence of unbound inputs.
-  - `name`: the name of the constructed `PDESystem`
+    actually be a fixed point; defaults to `false`; when `dynamics isa ODESystem`, the value
+    is inferred by the presence of unbound inputs and when `dynamics` is an `ODEFunction` or
+    an `ODEInputFunction`, the value is inferred by the type of `dynamics`.
+  - `name`: the name of the constructed `PDESystem`.
 """
 function NeuralLyapunovPDESystem(
-        dynamics::Function,
+        dynamics,
         lb,
         ub,
         spec::NeuralLyapunovSpecification;
@@ -99,7 +100,7 @@ function NeuralLyapunovPDESystem(
 end
 
 function NeuralLyapunovPDESystem(
-        dynamics::ODEFunction,
+        dynamics::Union{ODEFunction, ODEInputFunction},
         lb,
         ub,
         spec::NeuralLyapunovSpecification;
@@ -107,19 +108,22 @@ function NeuralLyapunovPDESystem(
         p = SciMLBase.NullParameters(),
         state_syms = [],
         parameter_syms = [],
-        policy_search::Bool = false,
+        policy_search::Bool = typeof(dynamics) <: ODEInputFunction,
         name
 )::PDESystem
     if dynamics.mass_matrix !== I
         throw(ErrorException("DAEs are not supported at this time. Please supply dynamics" *
                              " without a mass matrix."))
     end
-    if policy_search
+    if policy_search && (dynamics isa ODEFunction)
         throw(ErrorException("Got policy_search == true when dynamics were supplied as an" *
                              " ODEFunction f(x,p,t), so no input can be supplied."))
+    elseif !policy_search && (dynamics isa ODEInputFunction)
+        throw(ErrorException("Got policy_search == false when dynamics were supplied as " *
+                             "an ODEInputFunction f(x,u,p,t)."))
     end
 
-    # Extract state and parameter symbols from ODEFunction
+    # Extract state and parameter symbols from ODEFunction/ODEInputFunction
     s_syms, p_syms = if dynamics.sys isa ODESystem
         s_syms = Symbol.(operation.(unknowns(dynamics.sys)))
         p_syms = Symbol.(parameters(dynamics.sys))
@@ -136,7 +140,7 @@ function NeuralLyapunovPDESystem(
         ([], [])
     end
 
-    # Override ODEFunction state and parameter symbols when supplied
+    # Override ODEFunction/ODEInputFunction state and parameter symbols when supplied
     s_syms = if state_syms == []
         s_syms
     else
@@ -153,8 +157,8 @@ function NeuralLyapunovPDESystem(
         lb,
         ub,
         spec;
-        fixed_point = fixed_point,
-        p = p,
+        fixed_point,
+        p,
         state_syms = s_syms,
         parameter_syms = p_syms,
         policy_search = false,
@@ -202,7 +206,7 @@ function NeuralLyapunovPDESystem(
 
     ########################### Construct PDESystem ###########################
     return _NeuralLyapunovPDESystem(
-        f,
+        f.f,
         domains,
         spec,
         fixed_point,
@@ -215,7 +219,7 @@ function NeuralLyapunovPDESystem(
 end
 
 function _NeuralLyapunovPDESystem(
-        dynamics::Function,
+        dynamics,
         domains,
         spec::NeuralLyapunovSpecification,
         fixed_point,
@@ -307,6 +311,6 @@ function _NeuralLyapunovPDESystem(
         φ(state),
         params;
         defaults,
-        name = name
+        name
     )
 end

--- a/src/benchmark_harness.jl
+++ b/src/benchmark_harness.jl
@@ -56,18 +56,19 @@ arguments for each optimization pass.
     `SciMLBase.NullParameters()`; not used when `dynamics isa ODESystem`, then use the
     default parameter values of `dynamics`.
   - `state_syms`: an array of the `Symbol` representing each state; not used when `dynamics
-    isa ODESystem`, then the symbols from `dynamics` are used; if `dynamics isa ODEFunction`,
-    symbols stored there are used, unless overridden here; if not provided here and cannot
-    be inferred, `[:state1, :state2, ...]` will be used.
+    isa ODESystem` (in that case, the symbols from `dynamics` are used); if `dynamics` is an
+    `ODEFunction` or an `ODEInputFunction`, the symbols stored there are used, unless
+    overridden here; if not provided here and cannot be inferred, `[:state1, :state2, ...]`
+    will be used.
   - `parameter_syms`: an array of the `Symbol` representing each parameter; not used when
-    `dynamics isa ODESystem`, then the symbols from `dynamics` are used; if `dynamics isa
-    ODEFunction`, symbols stored there are used, unless overridden here; if not provided
-    here and cannot be inferred, `[:param1, :param2, ...]` will be used.
+    `dynamics isa ODESystem` (in that case, the symbols from `dynamics` are used); if
+    `dynamics` is an `ODEFunction` or an `ODEInputFunction`, the symbols stored there are
+    used, unless overridden here; if not provided here and cannot be inferred,
+    `[:param1, :param2, ...]` will be used.
   - `policy_search::Bool`: whether or not to include a loss term enforcing `fixed_point` to
-    actually be a fixed point; defaults to `false`; only used when `dynamics isa Function &&
-    !(dynamics isa ODEFunction)`; when `dynamics isa ODEFunction`, `policy_search` should
-    not be supplied (as it must be false); when `dynamics isa ODESystem`, value inferred by
-    the presence of unbound inputs.
+    actually be a fixed point; defaults to `false`; when `dynamics isa ODESystem`, the value
+    is inferred by the presence of unbound inputs and when `dynamics` is an `ODEFunction` or
+    an `ODEInputFunction`, the value is inferred by the type of `dynamics`.
   - `optimization_args`: arguments to be passed into the optimization solver, as a vector of
     `Pair`s. For more information, see the
     [Optimization.jl docs](https://docs.sciml.ai/Optimization/stable/API/solve/).
@@ -132,7 +133,7 @@ function benchmark(
         dynamics,
         bounds,
         spec;
-        fixed_point = fixed_point
+        fixed_point
     )
 
     params = parameters(dynamics)
@@ -191,7 +192,7 @@ function benchmark(
 end
 
 function benchmark(
-        dynamics::Function,
+        dynamics,
         lb,
         ub,
         spec,
@@ -223,11 +224,11 @@ function benchmark(
         lb,
         ub,
         spec;
-        fixed_point = fixed_point,
-        p = p,
-        state_syms = state_syms,
-        parameter_syms = parameter_syms,
-        policy_search = policy_search
+        fixed_point,
+        p,
+        state_syms,
+        parameter_syms,
+        policy_search
     )
 
     init_params = if init_params === nothing

--- a/src/conditions_specification.jl
+++ b/src/conditions_specification.jl
@@ -7,21 +7,20 @@ Allows the user to define the Lyapunov in terms of the neural network, potential
 structurally enforcing some Lyapunov conditions.
 
 # Fields
-  - `V(phi::Function, state, fixed_point)`: outputs the value of the Lyapunov function at
-    `state`.
-  - `V̇(phi::Function, J_phi::Function, dynamics::Function, state, params, t, fixed_point)`:
-    outputs the time derivative of the Lyapunov function at `state`.
-  - `f_call(dynamics::Function, phi::Function, state, params, t)`: outputs the derivative of
-    the state; this is useful for making closed-loop dynamics which depend on the neural
-    network, such as in the policy search case.
+  - `V(phi, state, fixed_point)`: outputs the value of the Lyapunov function at `state`.
+  - `V̇(phi, J_phi, dynamics, state, params, t, fixed_point)`: outputs the time derivative of
+    the Lyapunov function at `state`.
+  - `f_call(dynamics, phi, state, params, t)`: outputs the derivative of the state; this is
+    useful for making closed-loop dynamics which depend on the neural network, such as in
+    the policy search case.
   - `network_dim`: the dimension of the output of the neural network.
 
 `phi` and `J_phi` above are both functions of `state` alone.
 """
 struct NeuralLyapunovStructure
-    V::Function
-    V̇::Function
-    f_call::Function
+    V
+    V̇
+    f_call
     network_dim::Integer
 end
 

--- a/src/conditions_specification.jl
+++ b/src/conditions_specification.jl
@@ -17,11 +17,11 @@ structurally enforcing some Lyapunov conditions.
 
 `phi` and `J_phi` above are both functions of `state` alone.
 """
-struct NeuralLyapunovStructure
-    V
-    V̇
-    f_call
-    network_dim::Integer
+struct NeuralLyapunovStructure{TV, TDV, F, D <: Integer}
+    V::TV
+    V̇::TDV
+    f_call::F
+    network_dim::D
 end
 
 """

--- a/src/decrease_conditions.jl
+++ b/src/decrease_conditions.jl
@@ -55,11 +55,11 @@ In either case, the rectified linear unit `rectifier = (t) -> max(zero(t), t)` e
 represents the inequality, but differentiable approximations of this function may be
 employed.
 """
-struct LyapunovDecreaseCondition <: AbstractLyapunovDecreaseCondition
+struct LyapunovDecreaseCondition{RM, S, R} <: AbstractLyapunovDecreaseCondition
     check_decrease::Bool
-    rate_metric
-    strength
-    rectifier
+    rate_metric::RM
+    strength::S
+    rectifier::R
 end
 
 function check_decrease(cond::LyapunovDecreaseCondition)::Bool

--- a/src/decrease_conditions.jl
+++ b/src/decrease_conditions.jl
@@ -6,12 +6,12 @@ Specifies the form of the Lyapunov decrease condition to be used.
 # Fields
   - `check_decrease::Bool`: whether or not to train for negativity/nonpositivity of
     ``V̇(x)``.
-  - `rate_metric::Function`: should increase with ``V̇(x)``; used when
+  - `rate_metric`: should increase with second input, ``V̇(x)``; used when
     `check_decrease == true`.
-  - `strength::Function`: specifies the level of strictness for negativity training; should
-    be zero when the two inputs are equal and nonnegative otherwise; used when
-    `check_decrease == true`.
-  - `rectifier::Function`: positive when the input is positive and (approximately) zero when
+  - `strength`: specifies the level of strictness for negativity training; should be zero
+    when the two inputs are equal and nonnegative otherwise; used when `check_decrease` is
+    `true`.
+  - `rectifier`: positive when the input is positive and (approximately) zero when
     the input is negative.
 
 # Training conditions
@@ -57,9 +57,9 @@ employed.
 """
 struct LyapunovDecreaseCondition <: AbstractLyapunovDecreaseCondition
     check_decrease::Bool
-    rate_metric::Function
-    strength::Function
-    rectifier::Function
+    rate_metric
+    strength
+    rectifier
 end
 
 function check_decrease(cond::LyapunovDecreaseCondition)::Bool

--- a/src/decrease_conditions_RoA_aware.jl
+++ b/src/decrease_conditions_RoA_aware.jl
@@ -67,11 +67,12 @@ employed.
 
 See also: [`AbstractLyapunovDecreaseCondition`](@ref), [`LyapunovDecreaseCondition`](@ref)
 """
-struct RoAAwareDecreaseCondition <: AbstractLyapunovDecreaseCondition
-    cond::AbstractLyapunovDecreaseCondition
-    sigmoid
-    ρ::Real
-    out_of_RoA_penalty
+struct RoAAwareDecreaseCondition{C <: AbstractLyapunovDecreaseCondition, S, R <: Real, P} <:
+       AbstractLyapunovDecreaseCondition
+    cond::C
+    sigmoid::S
+    ρ::R
+    out_of_RoA_penalty::P
 end
 
 check_decrease(cond::RoAAwareDecreaseCondition)::Bool = check_decrease(cond.cond)

--- a/src/decrease_conditions_RoA_aware.jl
+++ b/src/decrease_conditions_RoA_aware.jl
@@ -7,11 +7,11 @@ attraction estimate of ``\\{ x : V(x) ≤ ρ \\}``.
 # Fields
   - `cond::AbstractLyapunovDecreaseCondition`: specifies the loss to be applied when
     ``V(x) ≤ ρ``.
-  - `sigmoid::Function`: approximately one when the input is positive and approximately zero
-    when the input is negative.
+  - `sigmoid`: a univariate function that outputs a value that is approximately one when the
+    input is positive and approximately zero when the input is negative.
   - `ρ`: the level of the sublevel set forming the estimate of the region of attraction.
-  - `out_of_RoA_penalty::Function`: a loss function to be applied penalizing points outside
-    the sublevel set forming the region of attraction estimate.
+  - `out_of_RoA_penalty`: a loss function to be applied penalizing points outside the
+    sublevel set forming the region of attraction estimate.
 
 # Training conditions
 
@@ -69,9 +69,9 @@ See also: [`AbstractLyapunovDecreaseCondition`](@ref), [`LyapunovDecreaseConditi
 """
 struct RoAAwareDecreaseCondition <: AbstractLyapunovDecreaseCondition
     cond::AbstractLyapunovDecreaseCondition
-    sigmoid::Function
+    sigmoid
     ρ::Real
-    out_of_RoA_penalty::Function
+    out_of_RoA_penalty
 end
 
 check_decrease(cond::RoAAwareDecreaseCondition)::Bool = check_decrease(cond.cond)
@@ -110,9 +110,9 @@ by `cond` only in that sublevel set.
 
 # Keyword Arguments
   - `ρ`: the target level such that the RoA will be ``\\{ x : V(x) ≤ ρ \\}``, defaults to 1.
-  - `out_of_RoA_penalty::Function`: specifies the loss to be applied when ``V(x) > ρ``,
+  - `out_of_RoA_penalty`: specifies the loss to be applied when ``V(x) > ρ``,
     defaults to no loss.
-  - `sigmoid::Function`: approximately one when the input is positive and approximately zero
+  - `sigmoid`: approximately one when the input is positive and approximately zero
     when the input is negative, defaults to unit step function.
 
 The loss applied to samples ``x`` such that ``V(x) > ρ`` is
@@ -136,7 +136,7 @@ function make_RoA_aware(
         out_of_RoA_penalty = (V, dVdt, state, fixed_point, _ρ) -> 0.0,
         sigmoid = (x) -> x .≥ zero.(x)
 )::RoAAwareDecreaseCondition
-    RoAAwareDecreaseCondition(
+    return RoAAwareDecreaseCondition(
         cond,
         sigmoid,
         ρ,

--- a/src/local_lyapunov.jl
+++ b/src/local_lyapunov.jl
@@ -37,7 +37,7 @@ function local_lyapunov(dynamics, state_dim, optimizer_factory, jac::AbstractMat
     JuMP.@variable(model, Q[1:state_dim, 1:state_dim], PSD)
 
     # V̇(x) = (x - x0) ⋅ ( (P A + A^T P) * (x - x0)), so we require P A + A^T P = -Q
-    JuMP.@constraint(model, P * jac + transpose(jac) * P .== -Q)
+    JuMP.@constraint(model, P * jac + transpose(jac) * P.==-Q)
 
     # Solve the semidefinite program and get the value of P
     JuMP.optimize!(model)

--- a/src/minimization_conditions.jl
+++ b/src/minimization_conditions.jl
@@ -45,10 +45,10 @@ In either case, the rectified linear unit `rectifier(t) = max(zero(t), t)` exact
 represents the inequality, but differentiable approximations of this function may be
 employed.
 """
-struct LyapunovMinimizationCondition <: AbstractLyapunovMinimizationCondition
+struct LyapunovMinimizationCondition{S, R} <: AbstractLyapunovMinimizationCondition
     check_nonnegativity::Bool
-    strength
-    rectifier
+    strength::S
+    rectifier::R
     check_fixed_point::Bool
 end
 

--- a/src/minimization_conditions.jl
+++ b/src/minimization_conditions.jl
@@ -5,12 +5,12 @@ Specifies the form of the Lyapunov minimization condition to be used.
 
 # Fields
   - `check_nonnegativity::Bool`: whether or not to train for positivity/nonnegativity of
-    ``V(x)``
-  - `strength::Function`: specifies the level of strictness for positivity training; should
-    be zero when the two inputs are equal and nonnegative otherwise; used when
-    `check_nonnegativity == true`
-  - `rectifier::Function`: positive when the input is positive and (approximately) zero when
-    the input is negative
+    ``V(x)``.
+  - `strength`: specifies the level of strictness for positivity training; should be zero
+    when the two inputs are equal and nonnegative otherwise; used when `check_nonnegativity`
+    is `true`.
+  - `rectifier`: positive when the input is positive and (approximately) zero when
+    the input is negative.
   - `check_fixed_point`: whether or not to train for ``V(x_0) = 0``.
 
 # Training conditions
@@ -47,8 +47,8 @@ employed.
 """
 struct LyapunovMinimizationCondition <: AbstractLyapunovMinimizationCondition
     check_nonnegativity::Bool
-    strength::Function
-    rectifier::Function
+    strength
+    rectifier
     check_fixed_point::Bool
 end
 

--- a/src/numerical_lyapunov_functions.jl
+++ b/src/numerical_lyapunov_functions.jl
@@ -37,14 +37,14 @@ function get_numerical_lyapunov_function(
         phi,
         θ,
         structure::NeuralLyapunovStructure,
-        dynamics::Function,
+        dynamics,
         fixed_point;
         p = SciMLBase.NullParameters(),
         use_V̇_structure = false,
         deriv = ForwardDiff.derivative,
         jac = ForwardDiff.jacobian,
         J_net = nothing
-)::Tuple{Function, Function}
+)
     # network_func is the numerical form of neural network output
     network_func = phi_to_net(phi, θ)
 

--- a/src/policy_search.jl
+++ b/src/policy_search.jl
@@ -10,9 +10,9 @@ Add dependence on the neural network to the dynamics in a [`NeuralLyapunovStruct
     through `control_structure`.
 
 # Keyword Arguments
-  - `control_structure::Function`: transforms the final `new_dims` outputs of the neural net
-    before passing them into the dynamics; defaults to `identity`, passing in the neural
-    network outputs unchanged.
+  - `control_structure`: function that transforms the final `new_dims` outputs of the neural
+    network before passing them into the dynamics; defaults to `identity`, passing in the
+    neural network outputs unchanged.
 
 The returned `NeuralLyapunovStructure` expects dynamics of the form `f(x, u, p, t)`, where
 `u` captures the dependence of dynamics on the neural network (e.g., through a control
@@ -24,7 +24,7 @@ as specified originally by `lyapunov_structure`.
 function add_policy_search(
         lyapunov_structure::NeuralLyapunovStructure,
         new_dims::Integer;
-        control_structure::Function = identity
+        control_structure = identity
 )::NeuralLyapunovStructure
     let V = lyapunov_structure.V, V̇ = lyapunov_structure.V̇,
         V_dim = lyapunov_structure.network_dim, u = control_structure
@@ -80,7 +80,7 @@ function get_policy(
         θ,
         network_dim::Integer,
         control_dim::Integer;
-        control_structure::Function = identity
+        control_structure = identity
 )
     network_func = phi_to_net(phi, θ; idx = (network_dim - control_dim + 1):network_dim)
 

--- a/test/damped_pendulum.jl
+++ b/test/damped_pendulum.jl
@@ -87,7 +87,7 @@ spec = NeuralLyapunovSpecification(
     lb,
     ub,
     spec;
-    p = p
+    p
 )
 
 ######################## Construct OptimizationProblem ########################
@@ -110,7 +110,7 @@ V̇ = get_numerical_lyapunov_function(
     structure,
     ODEFunction(dynamics),
     zeros(length(bounds));
-    p = p
+    p
 )
 
 ################################## Simulate ###################################

--- a/test/damped_pendulum_lux_2.jl
+++ b/test/damped_pendulum_lux_2.jl
@@ -92,7 +92,7 @@ V̇ = get_numerical_lyapunov_function(
     structure,
     ODEFunction(dynamics),
     zeros(length(lb));
-    p = p
+    p
 )
 
 ################################## Simulate ###################################

--- a/test/damped_sho.jl
+++ b/test/damped_sho.jl
@@ -65,7 +65,7 @@ spec = NeuralLyapunovSpecification(
     lb,
     ub,
     spec;
-    p = p
+    p
 )
 
 ######################## Construct OptimizationProblem ########################
@@ -87,7 +87,7 @@ V̇ = get_numerical_lyapunov_function(
     structure,
     f,
     fixed_point;
-    p = p,
+    p,
     use_V̇_structure = true
 )
 

--- a/test/inverted_pendulum.jl
+++ b/test/inverted_pendulum.jl
@@ -80,9 +80,9 @@ spec = NeuralLyapunovSpecification(
     ub,
     spec;
     fixed_point = upright_equilibrium,
-    p = p,
-    state_syms = state_syms,
-    parameter_syms = parameter_syms,
+    p,
+    state_syms,
+    parameter_syms,
     policy_search = true
 )
 
@@ -106,7 +106,7 @@ V̇ = get_numerical_lyapunov_function(
     structure,
     open_loop_pendulum_dynamics,
     upright_equilibrium;
-    p = p
+    p
 )
 
 u = get_policy(discretization.phi, res.u.depvar, dim_output, dim_u)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Corrects the faulty assumption that all functions will `<: Function`. Also includes some formatting changes throughout.
