### PR TITLE
Remove `mtkcompile` from `NeuralLyapunovPDESystem` and `benchmark`

### DIFF
--- a/docs/src/demos/policy_search.md
+++ b/docs/src/demos/policy_search.md
@@ -26,14 +26,13 @@ Random.seed!(200)
 ######################### Define dynamics and domain ##########################
 
 @named pendulum = Pendulum(; defaults = [0.5, 1.0])
-
-t, = independent_variables(pendulum)
-Dt = Differential(t)
-θ, = setdiff(unknowns(pendulum), inputs(pendulum))
+τ, = unbound_inputs(pendulum)
+pendulum = mtkcompile(pendulum; inputs = [τ], split = false)
+θ, ω = unknowns(pendulum)
 
 bounds = [
     θ ∈ (0, 2π),
-    Dt(θ) ∈ (-2.0, 2.0)
+    ω ∈ (-2.0, 2.0)
 ]
 
 upright_equilibrium = [π, 0.0]
@@ -106,10 +105,10 @@ res = Optimization.solve(prob, OptimizationOptimJL.BFGS(); maxiters = 300)
 net = discretization.phi
 _θ = res.u.depvar
 
-pendulum_io = mtkcompile(pendulum; inputs=inputs(pendulum), simplify = true, split = false)
-open_loop_pendulum_dynamics = ODEInputFunction(pendulum_io)
-state_order = unknowns(pendulum_io)
-p = [Symbolics.value(initial_conditions(pendulum)[param]) for param in parameters(pendulum)]
+open_loop_pendulum_dynamics = ODEInputFunction(pendulum)
+params = setdiff(parameters(pendulum), unbound_inputs(pendulum))
+ics = initial_conditions(pendulum)
+p = [Symbolics.value(ics[param]) for param in params]
 
 V, V̇ = get_numerical_lyapunov_function(
     net,
@@ -137,17 +136,16 @@ Since the angle ``\theta`` is periodic with period ``2\pi``, our box domain will
 
 ```@example policy_search
 using ModelingToolkit, NeuralLyapunovProblemLibrary
-using ModelingToolkit: inputs
+using ModelingToolkit: unbound_inputs
 
 @named pendulum = Pendulum(; defaults = [0.5, 1.0])
-
-t, = independent_variables(pendulum)
-Dt = Differential(t)
-θ, = setdiff(unknowns(pendulum), inputs(pendulum))
+τ, = unbound_inputs(pendulum)
+pendulum = mtkcompile(pendulum; inputs = [τ], split = false)
+θ, ω = unknowns(pendulum)
 
 bounds = [
     θ ∈ (0, 2π),
-    Dt(θ) ∈ (-2.0, 2.0)
+    ω ∈ (-2.0, 2.0)
 ]
 
 upright_equilibrium = [π, 0.0]
@@ -162,7 +160,7 @@ For more on that aspect, see the [NeuralPDE documentation](https://docs.sciml.ai
 
 ```@example policy_search
 using Lux, ComponentArrays
-import Boltz.Layers: PeriodicEmbedding
+using Boltz.Layers: PeriodicEmbedding
 using StableRNGs
 
 # Stable random number generator for doc stability
@@ -267,10 +265,10 @@ _θ = res.u.depvar
 We can use the result of the optimization problem to build the Lyapunov candidate as a Julia function, as well as extract our controller, using the [`get_policy`](@ref) function.
 
 ```@example policy_search
-pendulum_io = mtkcompile(pendulum; inputs=inputs(pendulum), simplify = true, split = false)
-open_loop_pendulum_dynamics = ODEInputFunction(pendulum_io)
-state_order = unknowns(pendulum_io)
-p = [Symbolics.value(initial_conditions(pendulum)[param]) for param in parameters(pendulum)]
+open_loop_pendulum_dynamics = ODEInputFunction(pendulum)
+params = setdiff(parameters(pendulum), unbound_inputs(pendulum))
+ics = initial_conditions(pendulum)
+p = [Symbolics.value(ics[param]) for param in params]
 
 V, V̇ = get_numerical_lyapunov_function(
     net,
@@ -374,20 +372,17 @@ Now, let's simulate the closed-loop dynamics to verify that the controller can g
 First, we'll start at the downward equilibrium:
 
 ```@example policy_search
-state_order = map(st -> SymbolicUtils.isterm(st) ? operation(st) : st, state_order)
-state_syms = Symbol.(state_order)
-
 closed_loop_dynamics = ODEFunction(
     (x, p, t) -> open_loop_pendulum_dynamics(x, u(x), p, t);
-    sys = SciMLBase.SymbolCache(state_syms, Symbol.(parameters(pendulum)))
+    sys = pendulum
 )
 
-using OrdinaryDiffEq: Tsit5
+using OrdinaryDiffEq: AutoTsit5, Rosenbrock23
 
 # Starting still at bottom ...
 downward_equilibrium = zeros(2)
 ode_prob = ODEProblem(closed_loop_dynamics, downward_equilibrium, [0.0, 120.0], p)
-sol = solve(ode_prob, Tsit5())
+sol = solve(ode_prob, AutoTsit5(Rosenbrock23()))
 plot(sol)
 ```
 
@@ -404,7 +399,7 @@ Then, we'll start at a random state:
 # Starting at a random point ...
 x0 = lb .+ rand(2) .* (ub .- lb)
 ode_prob = ODEProblem(closed_loop_dynamics, x0, [0.0, 150.0], p)
-sol = solve(ode_prob, Tsit5())
+sol = solve(ode_prob, AutoTsit5(Rosenbrock23()))
 plot(sol)
 ```
 

--- a/src/NeuralLyapunov.jl
+++ b/src/NeuralLyapunov.jl
@@ -6,7 +6,7 @@ using LinearAlgebra: I, dot, ⋅
 import Symbolics
 using Symbolics: @variables, Equation, Num, diff2term
 using ModelingToolkit: @named, @parameters, System, PDESystem, parameters, unknowns,
-    initial_conditions, operation, unbound_inputs, mtkcompile
+    initial_conditions, operation, unbound_inputs
 import SciMLBase
 using SciMLBase: ODEFunction, ODEInputFunction, ODEProblem, solve, EnsembleProblem,
     EnsembleDistributed, remake

--- a/src/NeuralLyapunovPDESystem.jl
+++ b/src/NeuralLyapunovPDESystem.jl
@@ -8,7 +8,9 @@ Construct a `ModelingToolkit.PDESystem` representing the specified neural Lyapun
   - `dynamics`: the dynamical system being analyzed, represented as a `System` or the
     function `f` such that `ẋ = f(x[, u], p, t)`; either way, the ODE should not depend on
     time and only `t = 0.0` will be used. (For an example of when `f` would have a `u`
-    argument, see [`add_policy_search`](@ref).)
+    argument, see [`add_policy_search`](@ref).) If `dynamics isa System`, call
+    `mtkcompile(dynamics)` before `NeuralLyapunovPDESystem`, or
+    `mtkcompile(dynamics; inputs = ..., split = false)` if the system has unbound inputs.
   - `bounds`: an array of domains, defining the training domain by bounding the states (and
     derivatives, when applicable) of `dynamics`; only used when `dynamics isa
     System`, otherwise use `lb` and `ub`.
@@ -188,21 +190,16 @@ function NeuralLyapunovPDESystem(
     ######################### Check for policy search #########################
     policy_search = !isempty(unbound_inputs(dynamics))
 
-    (f, x) = if policy_search
-        dynamics_io_sys = mtkcompile(
-            dynamics;
-            inputs = unbound_inputs(dynamics),
-            split = false
-        )
-        (ODEInputFunction(dynamics_io_sys), unknowns(dynamics_io_sys))
+    f = if policy_search
+        ODEInputFunction(dynamics)
     else
-        (ODEFunction(dynamics), unknowns(dynamics))
+        ODEFunction(dynamics)
     end
 
     ########################## Define state symbols ###########################
     # States should all be functions of time, but we just want the symbol
     # e.g., if the state is ω(t), we just want ω
-    _state = operation.(x)
+    _state = operation.(unknowns(dynamics))
     state_syms = Symbol.(_state)
     state = [first(@parameters $s) for s in state_syms]
 
@@ -223,7 +220,7 @@ function NeuralLyapunovPDESystem(
         spec,
         fixed_point,
         state,
-        parameters(dynamics),
+        setdiff(parameters(dynamics), unbound_inputs(dynamics)),
         initial_conditions(dynamics),
         policy_search,
         name

--- a/src/benchmark_harness.jl
+++ b/src/benchmark_harness.jl
@@ -40,7 +40,9 @@ the user or generated automatically).
   - `dynamics`: the dynamical system being analyzed, represented as a `System` or the
     function `f` such that `ẋ = f(x[, u], p, t)`; either way, the ODE should not depend on
     time and only `t = 0.0` will be used. (For an example of when `f` would have a `u`
-    argument, see [`add_policy_search`](@ref).)
+    argument, see [`add_policy_search`](@ref).) If `dynamics isa System`, call
+    `mtkcompile(dynamics)` before `benchmark`, or
+    `mtkcompile(dynamics; inputs = ..., split = false)` if the system has unbound inputs.
   - `bounds`: an array of domains, defining the training domain by bounding the states (and
     derivatives, when applicable) of `dynamics`; only used when `dynamics isa
     System`, otherwise use `lb` and `ub`.
@@ -162,16 +164,11 @@ function benchmark(
         ensemble_alg = EnsembleDistributed(),
         log_frequency = 50
     )
-    params = parameters(dynamics)
+    params = setdiff(parameters(dynamics), unbound_inputs(dynamics))
     f = if isempty(unbound_inputs(dynamics))
         ODEFunction(dynamics)
     else
-        dynamics_io_sys = mtkcompile(
-            dynamics;
-            inputs = unbound_inputs(dynamics),
-            split = false
-        )
-        ODEInputFunction(dynamics_io_sys; simplify = true, split = false)
+        ODEInputFunction(dynamics)
     end
 
     ics = initial_conditions(dynamics)

--- a/src/conditions_specification.jl
+++ b/src/conditions_specification.jl
@@ -35,6 +35,14 @@ function Base.show(io::IO, s::NeuralLyapunovStructure)
             # Regex to simplify broadcasting notation for better readability
             # Replace, e.g., [1:1] with [1]
             V = replace(V, r"\b(\d+):\1\b" => s"\1")
+            # Replace LinearAlgebra.dot(A, A) with ||A||^2 for better readability
+            dot_re = r"LinearAlgebra\.dot\(\s*((?:[^()]+|\((?1)\))*)\s*,\s*((?:[^()]+|\((?1)\))*)\s*\)"
+            V = replace(V, dot_re => s"||\1||²")
+            # Replace LinearAlgebra.dot with ⋅ for better readability
+            dot_re = r"LinearAlgebra\.dot\(\s*((?:[^()]+|\((?1)\))*)\s*,\s*((?:[^()]+|\((?2)\))*)\s*\)"
+            V = replace(V, dot_re => s"(\1)⋅(\2)")
+            # Replace ^2 with ²
+            V = replace(V, r"\^2" => "²")
             println(io, "    V(x) = ", V)
         catch e
             println(io, "    V(x) = <could not display: $(e)>")
@@ -49,6 +57,8 @@ function Base.show(io::IO, s::NeuralLyapunovStructure)
             # Replace LinearAlgebra.dot with ⋅ for better readability
             dot_re = r"LinearAlgebra\.dot\(\s*((?:[^()]+|\((?1)\))*)\s*,\s*((?:[^()]+|\((?2)\))*)\s*\)"
             V̇ = replace(V̇, dot_re => s"(\1)⋅(\2)")
+            # Replace ^2 with ²
+            V̇ = replace(V̇, r"\^2" => "²")
             println(io, "    V̇(x) = ", V̇)
         catch e
             println(io, "    V̇(x) = <could not display: $(e)>")

--- a/src/policy_search.jl
+++ b/src/policy_search.jl
@@ -26,7 +26,7 @@ add_policy_search(NonnegativeStructure(3), 1)
 # output
 NeuralLyapunovStructure
     Network dimension: 4
-    V(x) = (φ(x))[1]^2 + (φ(x))[2]^2 + (φ(x))[3]^2
+    V(x) = ||(φ(x))[1:3]||²
     V̇(x) = 2((φ(x))[1:3])⋅(f(x, (φ(x))[4], p, t)*(Jφ(x))[1:3])
     f_call(x) = f(x, (φ(x))[4], p, t)
 ```

--- a/src/structure_specification.jl
+++ b/src/structure_specification.jl
@@ -66,8 +66,8 @@ Dynamics are assumed to be in `f(state, p, t)` form, as in an `ODEFunction`. For
 julia> NonnegativeStructure(3; δ = 0.1)
 NeuralLyapunovStructure
     Network dimension: 3
-    V(x) = 0.1log(1.0 + (x - x_0)^2) + (φ(x))[1]^2 + (φ(x))[2]^2 + (φ(x))[3]^2
-    V̇(x) = 2(φ(x))⋅(f(x, p, t)*Jφ(x)) + (0.2(x - x_0)*f(x, p, t)) / (1.0 + (x - x_0)^2)
+    V(x) = 0.1log(1.0 + (x - x_0)²) + ||φ(x)||²
+    V̇(x) = 2(φ(x))⋅(f(x, p, t)*Jφ(x)) + (0.2(x - x_0)*f(x, p, t)) / (1.0 + (x - x_0)²)
     f_call(x) = f(x, p, t)
 ```
 

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -1,4 +1,5 @@
 using NeuralPDE, NeuralLyapunov, Lux, NeuralLyapunovProblemLibrary
+using ModelingToolkit: unbound_inputs
 import Boltz.Layers: PeriodicEmbedding, MLP
 using OptimizationOptimisers: Adam
 using OptimizationOptimJL: BFGS
@@ -216,15 +217,12 @@ end
     println("Benchmark: Damped Pendulum (ODESystem)")
 
     # Define dynamics and domain
-    @named damped_pendulum = Pendulum(; driven = false, defaults = Float32[5.0, 1.0])
-    t, = independent_variables(damped_pendulum)
-    θ, = unknowns(damped_pendulum)
-    Dt = Differential(t)
+    @mtkcompile damped_pendulum = Pendulum(; driven = false, defaults = Float32[5.0, 1.0])
+    θ, ω = unknowns(damped_pendulum)
 
-    damped_pendulum = mtkcompile(damped_pendulum)
     bounds = [
         θ ∈ Float32.((-π, π)),
-        Dt(θ) ∈ (-10.0f0, 10.0f0),
+        ω ∈ (-10.0f0, 10.0f0),
     ]
 
     # Define neural network discretization
@@ -300,13 +298,13 @@ end
     # Define dynamics and domain
     p = [0.5, 1.0]
     @named driven_pendulum = Pendulum(; driven = true, defaults = p)
-    t, = independent_variables(driven_pendulum)
-    θ, τ = unknowns(driven_pendulum)
+    τ, = unbound_inputs(driven_pendulum)
+    driven_pendulum = mtkcompile(driven_pendulum; inputs = [τ], split = false)
+    θ, ω = unknowns(driven_pendulum)
 
-    Dt = Differential(t)
     bounds = [
         θ ∈ (0, 2π),
-        Dt(θ) ∈ (-2.0, 2.0),
+        ω ∈ (-2.0, 2.0),
     ]
 
     upright_equilibrium = [π, 0.0]

--- a/test/benchmark_CUDA.jl
+++ b/test/benchmark_CUDA.jl
@@ -260,13 +260,13 @@ end
     # Define dynamics and domain
     p = Float32[0.5f0, 1.0f0]
     @named driven_pendulum = Pendulum(; driven = true, defaults = p)
-    t, = independent_variables(driven_pendulum)
-    θ, τ = unknowns(driven_pendulum)
+    τ, = unbound_inputs(driven_pendulum)
+    driven_pendulum = mtkcompile(driven_pendulum; inputs = [τ], split = false)
+    θ, ω = unknowns(driven_pendulum)
 
-    Dt = Differential(t)
     bounds = [
         θ ∈ Float32.((0, 2π)),
-        Dt(θ) ∈ (-2.0f0, 2.0f0),
+        ω ∈ (-2.0f0, 2.0f0),
     ]
 
     upright_equilibrium = Float32[π, 0.0f0]
@@ -346,7 +346,6 @@ end
         fixed_point = upright_equilibrium,
         optimization_args,
         endpoint_check,
-        classifier = (V, V̇, x) -> V̇ < zero(V̇) || endpoint_check(x),
         init_params = ps,
         init_states = st
     )

--- a/test/benchmark_CUDA.jl
+++ b/test/benchmark_CUDA.jl
@@ -1,4 +1,5 @@
 using NeuralPDE, NeuralLyapunov, NeuralLyapunovProblemLibrary
+using ModelingToolkit: unbound_inputs
 using OptimizationOptimisers: Adam
 using OptimizationOptimJL: BFGS
 using Random

--- a/test/damped_pendulum.jl
+++ b/test/damped_pendulum.jl
@@ -33,6 +33,8 @@ ub = [π, 10.0];
 p = [initial_conditions[param] for param in parameters(dynamics)]
 fixed_point = [0.0, 0.0]
 
+f = ODEFunction(dynamics)
+
 ####################### Specify neural Lyapunov problem #######################
 
 # Define neural network discretization
@@ -77,7 +79,7 @@ spec = NeuralLyapunovSpecification(structure, minimization_condition, decrease_c
 
 ############################# Construct PDESystem #############################
 
-@named pde_system = NeuralLyapunovPDESystem(ODEFunction(dynamics), lb, ub, spec; p)
+@named pde_system = NeuralLyapunovPDESystem(f, lb, ub, spec; p)
 
 ######################## Construct OptimizationProblem ########################
 
@@ -96,7 +98,7 @@ res = Optimization.solve(prob, Adam(0.001); maxiters = 500)
     discretization.phi,
     res.u.depvar,
     structure,
-    ODEFunction(dynamics),
+    f,
     zeros(length(bounds));
     p
 )

--- a/test/damped_pendulum_lux.jl
+++ b/test/damped_pendulum_lux.jl
@@ -20,6 +20,8 @@ lb = Float32[-π, -10];
 ub = Float32[π, 10];
 fixed_point = Float32[0.0, 0.0]
 
+f = ODEFunction(dynamics)
+
 ####################### Specify neural Lyapunov problem #######################
 
 # Define neural network discretization
@@ -61,7 +63,7 @@ spec = NeuralLyapunovSpecification(structure, minimization_condition, decrease_c
 
 ############################# Construct PDESystem #############################
 
-@named pde_system = NeuralLyapunovPDESystem(ODEFunction(dynamics), lb, ub, spec; p)
+@named pde_system = NeuralLyapunovPDESystem(f, lb, ub, spec; p)
 
 ######################## Construct OptimizationProblem ########################
 
@@ -80,7 +82,7 @@ res = Optimization.solve(prob, BFGS(); maxiters = 300)
     discretization.phi,
     res.u,
     structure,
-    ODEFunction(dynamics),
+    f,
     fixed_point;
     p
 )

--- a/test/damped_pendulum_lux_2.jl
+++ b/test/damped_pendulum_lux_2.jl
@@ -20,6 +20,8 @@ lb = Float32[-π, -10];
 ub = Float32[π, 10];
 fixed_point = Float32[0.0, 0.0]
 
+f = ODEFunction(dynamics)
+
 ####################### Specify neural Lyapunov problem #######################
 
 # Define neural network discretization
@@ -60,7 +62,7 @@ spec = NeuralLyapunovSpecification(structure, minimization_condition, decrease_c
 
 ############################# Construct PDESystem #############################
 
-@named pde_system = NeuralLyapunovPDESystem(ODEFunction(dynamics), lb, ub, spec; p)
+@named pde_system = NeuralLyapunovPDESystem(f, lb, ub, spec; p)
 
 ######################## Construct OptimizationProblem ########################
 
@@ -79,7 +81,7 @@ res = Optimization.solve(prob, BFGS(); maxiters = 300)
     discretization.phi,
     res.u,
     structure,
-    ODEFunction(dynamics),
+    f,
     fixed_point;
     p
 )

--- a/test/inverted_pendulum_ODESystem.jl
+++ b/test/inverted_pendulum_ODESystem.jl
@@ -1,5 +1,5 @@
 using NeuralPDE, Lux, ModelingToolkit, NeuralLyapunov, NeuralLyapunovProblemLibrary,
-        OrdinaryDiffEq
+    OrdinaryDiffEq
 using ModelingToolkit: unbound_inputs
 import Boltz.Layers: PeriodicEmbedding, MLP
 import Optimization

--- a/test/inverted_pendulum_ODESystem.jl
+++ b/test/inverted_pendulum_ODESystem.jl
@@ -1,4 +1,6 @@
-using NeuralPDE, Lux, ModelingToolkit, NeuralLyapunov, NeuralLyapunovProblemLibrary
+using NeuralPDE, Lux, ModelingToolkit, NeuralLyapunov, NeuralLyapunovProblemLibrary,
+        OrdinaryDiffEq
+using ModelingToolkit: unbound_inputs
 import Boltz.Layers: PeriodicEmbedding, MLP
 import Optimization
 using OptimizationOptimisers: Adam
@@ -15,13 +17,13 @@ println("Inverted Pendulum - Policy Search (ODESystem)")
 
 p = Float32[0.5, 1.0]
 @named driven_pendulum = Pendulum(; driven = true, defaults = p)
-t, = independent_variables(driven_pendulum)
-θ, τ = unknowns(driven_pendulum)
+τ, = unbound_inputs(driven_pendulum)
+driven_pendulum = mtkcompile(driven_pendulum; inputs = [τ], split = false)
+θ, ω = unknowns(driven_pendulum)
 
-Dt = Differential(t)
 bounds = [
     θ ∈ (0, 2π),
-    Dt(θ) ∈ (-2, 2),
+    ω ∈ (-2, 2),
 ]
 
 upright_equilibrium = Float32[π, 0.0]
@@ -93,9 +95,7 @@ res = Optimization.solve(prob, BFGS(); maxiters = 300)
 net = discretization.phi
 _θ = res.u.depvar
 
-driven_pendulum_io = mtkcompile(driven_pendulum; inputs = [τ], simplify = true, split = false)
-open_loop_pendulum_dynamics = ODEInputFunction(driven_pendulum_io)
-state_order = unknowns(driven_pendulum_io)
+open_loop_pendulum_dynamics = ODEInputFunction(driven_pendulum)
 
 (V, V̇) = get_numerical_lyapunov_function(
     net,
@@ -108,7 +108,10 @@ state_order = unknowns(driven_pendulum_io)
 
 u = get_policy(net, _θ, dim_output, dim_u)
 
-closed_loop_pendulum_dynamics(x) = open_loop_pendulum_dynamics(x, u(x), p, 0.0)
+closed_loop_dynamics = ODEFunction(
+    (x, p, t) -> open_loop_pendulum_dynamics(x, u(x), p, t);
+    sys = driven_pendulum
+)
 
 ################################## Simulate ###################################
 
@@ -134,12 +137,12 @@ x0 = (ub .- lb) .* rand(rng, Float32, 2, 100) .+ lb
 
 # Training should result in a locally stable fixed point at the upright equilibrium
 # Check for approximately zero angular acceleration
-@test abs(closed_loop_pendulum_dynamics(upright_equilibrium)[2]) < 3.0e-3
+@test abs(closed_loop_dynamics(upright_equilibrium, p, 0.0)[2]) < 3.0e-3
 # Check for nonpositive eigenvalues of the Jacobian
 #=
 @test maximum(
     eigvals(
-    ForwardDiff.jacobian(closed_loop_pendulum_dynamics, upright_equilibrium)
+    ForwardDiff.jacobian((x) -> closed_loop_dynamics(x, p, 0.0), upright_equilibrium)
 )
 ) ≤ 0
 =#
@@ -153,16 +156,6 @@ x0 = (ub .- lb) .* rand(rng, Float32, 2, 100) .+ lb
 @test sum(V̇_samples .> 0) / length(V_samples) < 0.01
 
 ################################## Simulate ###################################
-
-using OrdinaryDiffEq
-
-state_order = map(st -> SymbolicUtils.isterm(st) ? operation(st) : st, state_order)
-state_syms = Symbol.(state_order)
-
-closed_loop_dynamics = ODEFunction(
-    (x, p, t) -> open_loop_pendulum_dynamics(x, u(x), p, t);
-    sys = SciMLBase.SymbolCache(state_syms, Symbol.(parameters(driven_pendulum)))
-)
 
 # Starting still at bottom ...
 downward_equilibrium = zeros(Float32, 2)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Addresses #151. Now users will be required to call `mtkcompile` before these functions whether or not there are unbound inputs.

Additionally makes minor tweaks to `Base.show` to fix doctests.