### PR TITLE
Fix errors from `Base.show` implementations

### DIFF
--- a/docs/src/demos/damped_SHO.md
+++ b/docs/src/demos/damped_SHO.md
@@ -132,6 +132,7 @@ chain = [Chain(
              Dense(dim_hidden, 1)
          ) for _ in 1:dim_output]
 ps, st = Lux.setup(rng, chain)
+nothing # hide
 ```
 
 Since `Lux.setup` defaults to `Float32` parameters for `Dense` layers, we set up the bounds and parameters using `Float32` as well.
@@ -142,6 +143,9 @@ using ComponentArrays
 ps = ps |> ComponentArray |> f64
 st = st |> f64
 ```
+
+To train the model, we'll sample 1000 points from the domain using [`NeuralPDE.QuasiRandomTraining`](https://docs.sciml.ai/NeuralPDE/stable/manual/training_strategies/#NeuralPDE.QuasiRandomTraining).
+See the [NeuralPDE.jl docs](https://docs.sciml.ai/NeuralPDE/stable/) for more on how the `PDESystem` will be converted into an `OptimizationProblem`.
 
 ```@example SHO
 using NeuralPDE
@@ -156,28 +160,40 @@ We now define our Lyapunov candidate structure along with the form of the Lyapun
 
 For this example, let's use a Lyapunov candidate
 ```math
-V(x) = \lVert \phi(x) \rVert^2 + \delta \log \left( 1 + \lVert x \rVert^2 \right),
+V(x) = \lVert \phi(x) \rVert^2 + \delta \log \left( 1 + \lVert x \rVert^2 \right).
 ```
-which structurally enforces nonnegativity, but doesn't guarantee ``V([0, 0]) = 0``.
-We therefore don't need a term in the loss function enforcing ``V(x) > 0 \, \forall x \ne 0``, but we do need something enforcing ``V([0, 0]) = 0``.
-So, we use [`DontCheckNonnegativity(check_fixed_point = true)`](@ref).
-
-To train for exponential stability we use [`ExponentialStability`](@ref), but we must specify the rate of exponential decrease, which we know in this case to be ``\zeta \omega_0``.
 
 ```@example SHO
 using NeuralLyapunov
 
 # Define neural Lyapunov structure and corresponding minimization condition
 structure = NonnegativeStructure(dim_output; δ = 1.0f-6)
-minimization_condition = DontCheckNonnegativity(check_fixed_point = true)
+```
 
+This structure enforces nonnegativity, but doesn't guarantee ``V([0, 0]) = 0``.
+We therefore don't need a term in the loss function enforcing ``V(x) > 0 \, \forall x \ne 0``, but we do need something enforcing ``V([0, 0]) = 0``.
+So, we use [`DontCheckNonnegativity(check_fixed_point = true)`](@ref).
+
+```@example SHO
+minimization_condition = DontCheckNonnegativity(check_fixed_point = true)
+```
+
+To train for exponential stability we use [`ExponentialStability`](@ref), but we must specify the rate of exponential decrease, which we know in this case to be ``\zeta \omega_0``.
+
+```@example SHO
 # Define Lyapunov decrease condition
 # Damped SHO has exponential stability at a rate of k = ζ * ω_0, so we train to certify that
 decrease_condition = ExponentialStability(prod(p))
+```
 
+We package these in a `NeuralLyapunovSpecification` and use it to construct a `PDESystem`.
+
+```@example SHO
 # Construct neural Lyapunov specification
 spec = NeuralLyapunovSpecification(structure, minimization_condition, decrease_condition)
+```
 
+```@example SHO
 # Construct PDESystem
 @named pde_system = NeuralLyapunovPDESystem(dynamics, lb, ub, spec; p)
 ```

--- a/docs/src/demos/policy_search.md
+++ b/docs/src/demos/policy_search.md
@@ -132,8 +132,6 @@ Random.seed!(200)
 
 In this example, we'll use the [`Pendulum`](@ref) model in [NeuralLyaupnovProblemLibrary.jl](../lib.md).
 
-Since the angle ``\theta`` is periodic with period ``2\pi``, our box domain will be one period in ``\theta`` and an interval in ``\frac{d\theta}{dt}``.
-
 ```@example policy_search
 using ModelingToolkit, NeuralLyapunovProblemLibrary
 using ModelingToolkit: unbound_inputs
@@ -141,14 +139,19 @@ using ModelingToolkit: unbound_inputs
 @named pendulum = Pendulum(; defaults = [0.5, 1.0])
 τ, = unbound_inputs(pendulum)
 pendulum = mtkcompile(pendulum; inputs = [τ], split = false)
+```
+
+Since the angle ``\theta`` is periodic with period ``2\pi``, our box domain will be one period in ``\theta`` and an interval in ``\frac{d\theta}{dt}``.
+
+```@example policy_search
+upright_equilibrium = [π, 0.0]
+
 θ, ω = unknowns(pendulum)
 
 bounds = [
     θ ∈ (0, 2π),
     ω ∈ (-2.0, 2.0)
 ]
-
-upright_equilibrium = [π, 0.0]
 ```
 
 We'll use an architecture that's ``2\pi``-periodic in ``\theta`` so that we can train on just one period of ``\theta`` and don't need to add any periodic boundary conditions.
@@ -182,6 +185,7 @@ chain = [Chain(
 ps, st = Lux.setup(rng, chain)
 ps = ps |> ComponentArray |> f64
 st = st |> f64
+nothing #hide
 ```
 
 ```@example policy_search

--- a/docs/src/demos/roa_estimation.md
+++ b/docs/src/demos/roa_estimation.md
@@ -127,6 +127,7 @@ chain = [Chain(
 ps, st = Lux.setup(rng, chain)
 ps = ps |> ComponentArray |> f64
 st = st |> f64
+nothing # hide
 ```
 
 ```@example RoA
@@ -147,18 +148,28 @@ V(x) = \left( 1 + \lVert \phi(x) \rVert^2 \right) \log \left( 1 + \lVert x \rVer
 which structurally enforces positive definiteness.
 We therefore use [`DontCheckNonnegativity()`](@ref).
 
-We only require asymptotic stability in this example, but we use [`make_RoA_aware`](@ref) to only penalize positive values of ``\dot{V}(x)`` when ``V(x) \le 1``.
-
 ```@example RoA
 using NeuralLyapunov
 
 # Define neural Lyapunov structure
 structure = PositiveSemiDefiniteStructure(dim_output)
 minimization_condition = DontCheckNonnegativity()
+```
 
+We only require asymptotic stability in this example, but we use [`make_RoA_aware`](@ref) to only penalize positive values of ``\dot{V}(x)`` when ``V(x) \le 1``.
+
+```@example RoA
 # Define Lyapunov decrease condition
-decrease_condition = make_RoA_aware(AsymptoticStability())
+decrease_condition = AsymptoticStability()
+```
 
+```@example RoA
+decrease_condition = make_RoA_aware(decrease_condition)
+```
+
+We package these in a `NeuralLyapunovSpecification` and use it to construct a `PDESystem`.
+
+```@example RoA
 # Construct neural Lyapunov specification
 spec = NeuralLyapunovSpecification(structure, minimization_condition, decrease_condition)
 

--- a/src/conditions_specification.jl
+++ b/src/conditions_specification.jl
@@ -45,7 +45,7 @@ function Base.show(io::IO, s::NeuralLyapunovStructure)
             V = replace(V, r"\^2" => "²")
             println(io, "    V(x) = ", V)
         catch e
-            println(io, "    V(x) = <could not display: $(e)>")
+            println(io, "    V(x) = <could not display: $e>")
         end
         try
             V̇ = string(s.V̇(φ, Jφ, f, x, p, t, x_0))

--- a/src/decrease_conditions.jl
+++ b/src/decrease_conditions.jl
@@ -70,6 +70,10 @@ function Base.show(io::IO, cond::LyapunovDecreaseCondition)
         str = string(-cond.strength(x, x_0))
         rec = string(cond.rectifier(a))
         rm = string(cond.rate_metric(V(x), V̇(x)))
+        # Replace ^2 with ²
+        str = replace(str, r"\^2" => "²")
+        rec = replace(rec, r"\^2" => "²")
+        rm = replace(rm, r"\^2" => "²")
         println(io, "    Trains for $rm ≤ $str")
         print(io, "    with approximation a ≤ 0 => $rec ≈ 0")
     else
@@ -154,14 +158,14 @@ but differentiable approximations of this function may be employed.
 ```jldoctest
 julia> AsymptoticStability()
 LyapunovDecreaseCondition
-    Trains for V̇(x) ≤ -1.0e-6((x - x_0)^2)
+    Trains for V̇(x) ≤ -1.0e-6((x - x_0)²)
     with approximation a ≤ 0 => max(0, a) ≈ 0
 
 julia> softplus = (t) -> log(one(t) + exp(t));
 
 julia> AsymptoticStability(C = 0.1, rectifier = softplus)
 LyapunovDecreaseCondition
-    Trains for V̇(x) ≤ -0.1((x - x_0)^2)
+    Trains for V̇(x) ≤ -0.1((x - x_0)²)
     with approximation a ≤ 0 => log(1 + exp(a)) ≈ 0
 ```
 """

--- a/src/decrease_conditions.jl
+++ b/src/decrease_conditions.jl
@@ -66,16 +66,36 @@ function Base.show(io::IO, cond::LyapunovDecreaseCondition)
     println(io, "LyapunovDecreaseCondition")
 
     if cond.check_decrease
-        @variables x x_0 a V(..) V̇(..)
-        str = string(-cond.strength(x, x_0))
-        rec = string(cond.rectifier(a))
-        rm = string(cond.rate_metric(V(x), V̇(x)))
-        # Replace ^2 with ²
-        str = replace(str, r"\^2" => "²")
-        rec = replace(rec, r"\^2" => "²")
-        rm = replace(rm, r"\^2" => "²")
-        println(io, "    Trains for $rm ≤ $str")
-        print(io, "    with approximation a ≤ 0 => $rec ≈ 0")
+        print(io, "    Trains for ")
+
+        try
+            @variables x V(..) V̇(..)
+            rm = string(cond.rate_metric(V(x), V̇(x)))
+            # Replace ^2 with ²
+            rm = replace(rm, r"\^2" => "²")
+            print(io, "$rm ≤ ")
+        catch e
+            print(io, "<could not display rate_metric(V(x), V̇(x)): $e> ≤ ")
+        end
+
+        try
+            @variables x x_0
+            str = string(-cond.strength(x, x_0))
+            # Replace ^2 with ²
+            str = replace(str, r"\^2" => "²")
+            println(io, "$str")
+        catch e
+            println(io, "<could not display strength(x, x_0): $e>")
+        end
+
+        try
+            @variables a
+            rec = string(cond.rectifier(a))
+            rec = replace(rec, r"\^2" => "²")
+            print(io, "    with approximation a ≤ 0 => $rec ≈ 0")
+        catch e
+            println(io, "    with approximation a ≤ 0 => <could not display rectifier(a): $e> ≈ 0")
+        end
     else
         print(io, "    Does not train for decrease of V along trajectories")
     end

--- a/src/minimization_conditions.jl
+++ b/src/minimization_conditions.jl
@@ -58,8 +58,10 @@ function Base.show(io::IO, cond::LyapunovMinimizationCondition)
     if cond.check_nonnegativity
         @variables x x_0 a
         str = string(cond.strength(x, x_0))
+        str = replace(str, r"\^2" => "²")
         println(io, "    Trains for V(x) ≥ $str")
         rec = string(cond.rectifier(a))
+        rec = replace(rec, r"\^2" => "²")
         println(io, "    with approximation a ≤ 0 => $rec ≈ 0")
     else
         println(io, "    Does not train for nonnegativity of V(x)")
@@ -111,7 +113,7 @@ exactly represents ``V(x) ≥ C \\lVert x - x_0 \\rVert^2``. ``C`` defaults to `
 ```jldoctest
 julia> StrictlyPositiveDefinite()
 LyapunovMinimizationCondition
-    Trains for V(x) ≥ 1.0e-6((x - x_0)^2)
+    Trains for V(x) ≥ 1.0e-6((x - x_0)²)
     with approximation a ≤ 0 => max(0, a) ≈ 0
     Trains for V(x_0) = 0
 
@@ -119,7 +121,7 @@ julia> softplus = (t) -> log(one(t) + exp(t));
 
 julia> StrictlyPositiveDefinite(C = 0.1, rectifier = softplus, check_fixed_point = false)
 LyapunovMinimizationCondition
-    Trains for V(x) ≥ 0.1((x - x_0)^2)
+    Trains for V(x) ≥ 0.1((x - x_0)²)
     with approximation a ≤ 0 => log(1 + exp(a)) ≈ 0
     Does not train for V(x_0) = 0
 ```

--- a/src/minimization_conditions.jl
+++ b/src/minimization_conditions.jl
@@ -56,13 +56,22 @@ function Base.show(io::IO, cond::LyapunovMinimizationCondition)
     println(io, "LyapunovMinimizationCondition")
 
     if cond.check_nonnegativity
-        @variables x x_0 a
-        str = string(cond.strength(x, x_0))
-        str = replace(str, r"\^2" => "²")
-        println(io, "    Trains for V(x) ≥ $str")
-        rec = string(cond.rectifier(a))
-        rec = replace(rec, r"\^2" => "²")
-        println(io, "    with approximation a ≤ 0 => $rec ≈ 0")
+        try
+            @variables x x_0
+            str = string(cond.strength(x, x_0))
+            str = replace(str, r"\^2" => "²")
+            println(io, "    Trains for V(x) ≥ $str")
+        catch e
+            println(io, "    Trains for V(x) ≥ <could not display strength(x, x_0): $e>")
+        end
+        try
+            @variables a
+            rec = string(cond.rectifier(a))
+            rec = replace(rec, r"\^2" => "²")
+            println(io, "    with approximation a ≤ 0 => $rec ≈ 0")
+        catch e
+            println(io, "    with approximation a ≤ 0 => <could not display rectifier(a): $e> ≈ 0")
+        end
     else
         println(io, "    Does not train for nonnegativity of V(x)")
     end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

`Base.show` implementations use ModelingToolkit to trace functions describing `V` and its derivative. Tracing fails and errors sometimes, so all tracing has now been surrounded by `try ... catch` statements.

Additionally adds a simple regex for prettier printing of squared terms.