### PR TITLE
Only plot planar quadrotor thrusts when they are nonzero

### DIFF
--- a/lib/NeuralLyapunovProblemLibrary/ext/NeuralLyapunovProblemLibraryPlotsExt/quadrotor_plot.jl
+++ b/lib/NeuralLyapunovProblemLibrary/ext/NeuralLyapunovProblemLibraryPlotsExt/quadrotor_plot.jl
@@ -93,8 +93,12 @@ function NeuralLyapunovProblemLibrary.plot_quadrotor_planar(
 
         # Rotors
         top_rotor, bottom_rotor = rotors(x[i], y[i], θ[i], u1[i], u2[i], r)
-        plot!(top_rotor..., arrow = true, linewidth = 2, color = :red)
-        plot!(bottom_rotor..., arrow = true, linewidth = 2, color = :red)
+        if u1[i] > 0
+            plot!(top_rotor..., arrow = true, linewidth = 2, color = :red)
+        end
+        if u2[i] > 0
+            plot!(bottom_rotor..., arrow = true, linewidth = 2, color = :red)
+        end
 
         # Trajectory so far
         traj_x = x[1:i]


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This change avoids a NaN warning that was occurring when the planar quadrotor was animated and a thrust was ever 0.