### PR TITLE
More robust doctests

### DIFF
--- a/src/conditions_specification.jl
+++ b/src/conditions_specification.jl
@@ -147,7 +147,7 @@ Specifies a neural Lyapunov problem.
     decrease condition will be enforced.
 
 # Example
-```jldoctest; filter = r"(?m)^\\s*V̇\\(x\\)\\s*=\\s*2\\s*(?=.*φ\\(x\\))(?=.*∇φ\\(x\\))(?=.*f\\(x,\\s*p,\\s*t\\))(?:\\s*(?:φ\\(x\\)|∇φ\\(x\\)|f\\(x,\\s*p,\\s*t\\))\\s*(?:\\*\\s*(?:φ\\(x\\)|∇φ\\(x\\)|f\\(x,\\s*p,\\s*t\\))\\s*){2})\$"
+```jldoctest; filter = [r"f\\(\\s*x,\\s*p,\\s*t\\s*\\)" => "ẋ", r"φ\\(x\\)" => "φ", r"\\s*\\*\\s*" => "", r"∇φ" => "∇", r"(?m)\\s*V̇\\(x\\)\\s*=\\s*(2|φ|∇|ẋ){4}\$"]
 julia> NeuralLyapunovSpecification(NonnegativeStructure(1), PositiveSemiDefinite(), StabilityISL())
 NeuralLyapunovSpecification
     Structure:

--- a/src/conditions_specification.jl
+++ b/src/conditions_specification.jl
@@ -38,6 +38,8 @@ function Base.show(io::IO, s::NeuralLyapunovStructure)
             # Replace LinearAlgebra.dot(A, A) with ||A||^2 for better readability
             dot_re = r"LinearAlgebra\.dot\(\s*((?:[^()]+|\((?1)\))*)\s*,\s*((?:[^()]+|\((?1)\))*)\s*\)"
             V = replace(V, dot_re => s"||\1||²")
+            # Replace abs2(A) with ||A||^2 for better readability
+            V = replace(V, r"abs2\(\s*((?:[^()]+|\((?1)\))*)\s*\)" => s"||\1||²")
             # Replace LinearAlgebra.dot with ⋅ for better readability
             dot_re = r"LinearAlgebra\.dot\(\s*((?:[^()]+|\((?1)\))*)\s*,\s*((?:[^()]+|\((?2)\))*)\s*\)"
             V = replace(V, dot_re => s"(\1)⋅(\2)")
@@ -54,11 +56,15 @@ function Base.show(io::IO, s::NeuralLyapunovStructure)
             V̇ = replace(V̇, r",\s*Colon\(\)" => "")
             # Replace, e.g., [1:1] with [1]
             V̇ = replace(V̇, r"\b(\d+):\1\b" => s"\1")
+            # Replace abs2(A) with ||A||^2 for better readability
+            V̇ = replace(V̇, r"abs2\(\s*((?:[^()]+|\((?1)\))*)\s*\)" => s"||\1||²")
             # Replace LinearAlgebra.dot with ⋅ for better readability
             dot_re = r"LinearAlgebra\.dot\(\s*((?:[^()]+|\((?1)\))*)\s*,\s*((?:[^()]+|\((?2)\))*)\s*\)"
             V̇ = replace(V̇, dot_re => s"(\1)⋅(\2)")
             # Replace ^2 with ²
             V̇ = replace(V̇, r"\^2" => "²")
+            # Replace Differential(x, 1)(φ(x)) with Jφ(x) for better readability
+            V̇ = replace(V̇, r"Differential\(x, 1\)\(φ\(x\)\)" => "Jφ(x)")
             println(io, "    V̇(x) = ", V̇)
         catch e
             println(io, "    V̇(x) = <could not display: $(e)>")
@@ -77,12 +83,24 @@ function Base.show(io::IO, s::NeuralLyapunovStructure)
         println(io, "NeuralLyapunovStructure")
         println(io, "    Network dimension: ", n)
         try
-            println(io, "    V(x) = ", s.V(φ, x, x_0))
+            V = string(s.V(φ, x, x_0))
+            # Replace abs2(A) with ||A||² for better readability
+            V = replace(V, r"abs2\(\s*((?:[^()]+|\((?1)\))*)\s*\)" => s"||\1||²")
+            # Replace ^2 with ²
+            V = replace(V, r"\^2" => "²")
+            println(io, "    V(x) = ", V)
         catch e
             println(io, "    V(x) = <could not display: $(e)>")
         end
         try
-            println(io, "    V̇(x) = ", s.V̇(φ, ∇φ, f, x, p, t, x_0))
+            V̇ = string(s.V̇(φ, ∇φ, f, x, p, t, x_0))
+            # Replace abs2(A) with ||A||^2 for better readability
+            V̇ = replace(V̇, r"abs2\(\s*((?:[^()]+|\((?1)\))*)\s*\)" => s"||\1||²")
+            # Replace ^2 with ²
+            V̇ = replace(V̇, r"\^2" => "²")
+            # Replace Differential(x, 1)(φ(x)) with ∇φ(x) for better readability
+            V̇ = replace(V̇, r"Differential\(x, 1\)\(φ\(x\)\)" => "∇φ(x)")
+            println(io, "    V̇(x) = ", V̇)
         catch e
             println(io, "    V̇(x) = <could not display: $(e)>")
         end
@@ -129,13 +147,13 @@ Specifies a neural Lyapunov problem.
     decrease condition will be enforced.
 
 # Example
-```jldoctest
+```jldoctest; filter = r"(?m)^\\s*V̇\\(x\\)\\s*=\\s*2\\s*(?=.*φ\\(x\\))(?=.*∇φ\\(x\\))(?=.*f\\(x,\\s*p,\\s*t\\))(?:\\s*(?:φ\\(x\\)|∇φ\\(x\\)|f\\(x,\\s*p,\\s*t\\))\\s*(?:\\*\\s*(?:φ\\(x\\)|∇φ\\(x\\)|f\\(x,\\s*p,\\s*t\\))\\s*){2})\$"
 julia> NeuralLyapunovSpecification(NonnegativeStructure(1), PositiveSemiDefinite(), StabilityISL())
 NeuralLyapunovSpecification
     Structure:
         NeuralLyapunovStructure
             Network dimension: 1
-            V(x) = φ(x)^2
+            V(x) = φ(x)²
             V̇(x) = 2φ(x)*∇φ(x)*f(x, p, t)
             f_call(x) = f(x, p, t)
     Minimization Condition:

--- a/src/decrease_conditions.jl
+++ b/src/decrease_conditions.jl
@@ -216,7 +216,7 @@ but differentiable approximations of this function may be employed.
 
 # Examples
 
-```jldoctest
+```jldoctest; filter = r"(?m)\\s*Trains for\\s+(?:(?:\\d+\\.?\\d*|\\.\\d+)V\\(x\\)\\s*\\+\\s*V̇\\(x\\)|V̇\\(x\\)\\s*\\+\\s*(?:\\d+\\.?\\d*|\\.\\d+)V\\(x\\))\\s*≤\\s*0\$"
 julia> ExponentialStability(0.5)
 LyapunovDecreaseCondition
     Trains for 0.5V(x) + V̇(x) ≤ 0
@@ -224,9 +224,9 @@ LyapunovDecreaseCondition
 
 julia> softplus = (t) -> log(one(t) + exp(t));
 
-julia> ExponentialStability(5.0; rectifier = softplus)
+julia> ExponentialStability(5; rectifier = softplus)
 LyapunovDecreaseCondition
-    Trains for 5.0V(x) + V̇(x) ≤ 0
+    Trains for 5V(x) + V̇(x) ≤ 0
     with approximation a ≤ 0 => log(1 + exp(a)) ≈ 0
 ```
 """

--- a/src/decrease_conditions.jl
+++ b/src/decrease_conditions.jl
@@ -216,7 +216,7 @@ but differentiable approximations of this function may be employed.
 
 # Examples
 
-```jldoctest; filter = r"(?m)\\s*Trains for\\s+(?:(?:\\d+\\.?\\d*|\\.\\d+)V\\(x\\)\\s*\\+\\s*V̇\\(x\\)|V̇\\(x\\)\\s*\\+\\s*(?:\\d+\\.?\\d*|\\.\\d+)V\\(x\\))\\s*≤\\s*0\$"
+```jldoctest; filter = [r"0?\\.?5V" => "V", r"(?m)\\s*Trains for (V|V̇)\\(x\\) + (V|V̇)\\(x\\) ≤ 0\$"]
 julia> ExponentialStability(0.5)
 LyapunovDecreaseCondition
     Trains for 0.5V(x) + V̇(x) ≤ 0

--- a/src/structure_specification.jl
+++ b/src/structure_specification.jl
@@ -11,7 +11,7 @@ Dynamics are assumed to be in `f(state, p, t)` form, as in an `ODEFunction`. For
 `f(state, input, p, t)`, consider using [`add_policy_search`](@ref).
 
 # Example
-```jldoctest
+```jldoctest; filter = r"(?m)^\\s*V̇\\(x\\)\\s*=\\s*(?=.*f\\(x,\\s*p,\\s*t\\))(?=.*∇φ\\(x\\))(?:\\s*(?:f\\(x,\\s*p,\\s*t\\)\\s*\\*\\s*∇φ\\(x\\)|∇φ\\(x\\)\\s*\\*\\s*f\\(x,\\s*p,\\s*t\\))\\s*)\$"
 julia> NoAdditionalStructure()
 NeuralLyapunovStructure
     Network dimension: 1
@@ -62,12 +62,12 @@ Dynamics are assumed to be in `f(state, p, t)` form, as in an `ODEFunction`. For
 `f(state, input, p, t)`, consider using [`add_policy_search`](@ref).
 
 # Example
-```jldoctest
+```jldoctest; filter = [r"(?m)\\s*V\\(x\\)\\s*=\\s*(0\\.1\\s*log\\(\\s*1\\s*\\+\\s*\\(x\\s*-\\s*x_0\\)²\\)|\\|\\|\\s*φ\\(x\\)\\s*\\|\\|²)\\s*(?:\\+\\s*(?:0\\.1\\s*log\\(\\s*1\\s*\\+\\s*\\(x\\s*-\\s*x_0\\)²\\)|\\|\\|\\s*φ\\(x\\)\\s*\\|\\|²))\$", r"(?m)\\s*V̇\\(x\\)\\s*=\\s*(?:2\\(φ\\(x\\)\\)\\s*⋅\\s*\\(f\\(x,\\s*p,\\s*t\\)\\s*\\*\\s*Jφ\\(x\\)\\)\\s*\\+\\s*\\(0\\.2\\(x\\s*-\\s*x_0\\)\\s*\\*\\s*f\\(x,\\s*p,\\s*t\\)\\)\\s*/\\s*\\(1\\s*\\+\\s*\\(x\\s*-\\s*x_0\\)²\\)|\\(0\\.2\\(x\\s*-\\s*x_0\\)\\s*\\*\\s*f\\(x,\\s*p,\\s*t\\)\\)\\s*/\\s*\\(1\\s*\\+\\s*\\(x\\s*-\\s*x_0\\)²\\)\\s*\\+\\s*2\\(φ\\(x\\)\\)\\s*⋅\\s*\\(f\\(x,\\s*p,\\s*t\\)\\s*\\*\\s*Jφ\\(x\\)\\))\$"]
 julia> NonnegativeStructure(3; δ = 0.1)
 NeuralLyapunovStructure
     Network dimension: 3
-    V(x) = 0.1log(1.0 + (x - x_0)²) + ||φ(x)||²
-    V̇(x) = 2(φ(x))⋅(f(x, p, t)*Jφ(x)) + (0.2(x - x_0)*f(x, p, t)) / (1.0 + (x - x_0)²)
+    V(x) = 0.1log(1 + (x - x_0)²) + ||φ(x)||²
+    V̇(x) = 2(φ(x))⋅(f(x, p, t)*Jφ(x)) + (0.2(x - x_0)*f(x, p, t)) / (1 + (x - x_0)²)
     f_call(x) = f(x, p, t)
 ```
 
@@ -75,12 +75,12 @@ See also: [`DontCheckNonnegativity`](@ref)
 """
 function NonnegativeStructure(
         network_dim::Integer;
-        δ::Real = 0.0,
-        pos_def = (x, x0) -> log(1.0 + (x - x0) ⋅ (x - x0)),
+        δ::Real = 0,
+        pos_def = (x, x0) -> log(1 + (x - x0) ⋅ (x - x0)),
         grad_pos_def = nothing,
         grad = ForwardDiff.gradient
     )::NeuralLyapunovStructure
-    return if δ == 0.0
+    return if δ == 0
         NeuralLyapunovStructure(
             (net, x, x0) -> net(x) ⋅ net(x),
             (net, J_net, f, x, p, t, x0) -> 2 * dot(net(x), J_net(x), f(x, p, t)),
@@ -149,12 +149,12 @@ Dynamics are assumed to be in `f(state, p, t)` form, as in an `ODEFunction`. For
 `f(state, input, p, t)`, consider using [`add_policy_search`](@ref).
 
 # Example
-```jldoctest
-julia> PositiveSemiDefiniteStructure(1)
+```jldoctest; filter = [r"\\(?2x - 2x_0\\)?" => "2(x - x_0)", r"\\(?x - x_0\\)?" => "Δ", r"\\|\\|Δ\\|\\|²" => "Δ²", r"φ\\(x\\)" => "φ", r"\\(?1\\s*\\+\\s*φ²\\)?" => "Y", r"\\s*\\*\\s*" => "", r"(?m)\\s*V\\(x\\)\\s*=\\s*(?:Δ²Y|YΔ²)\$", r"f\\(\\s*x,\\s*p,\\s*t\\s*\\)" => "ẋ", r"(2ΔẋY|2ΔYẋ|ẋ2ΔY|ẋY2Δ|Yẋ2Δ|Y2Δẋ)" => "A", r"(2|∇φ|ẋ|Δ²|φ){5}" => "B", r"(?m)\\s*V̇\\(x\\)\\s*=\\s*(A|B)\\s*\\+\\s*(A|B)\$"]
+julia> PositiveSemiDefiniteStructure(1; pos_def = (x, x0) -> sum(abs2, x - x0))
 NeuralLyapunovStructure
     Network dimension: 1
-    V(x) = log(1.0 + (x - x_0)^2)*(1 + φ(x)^2)
-    V̇(x) = (2(x - x_0)*(1 + φ(x)^2)*f(x, p, t)) / (1.0 + (x - x_0)^2) + 2log(1.0 + (x - x_0)^2)*φ(x)*Differential(x, 1)(φ(x))*f(x, p, t)
+    V(x) = (1 + φ(x)²)*||x - x_0||²
+    V̇(x) = (2x - 2x_0)*f(x, p, t)*(1 + φ(x)²) + 2∇φ(x)*f(x, p, t)*||x - x_0||²*φ(x)
     f_call(x) = f(x, p, t)
 ```
 
@@ -162,7 +162,7 @@ See also: [`DontCheckNonnegativity`](@ref)
 """
 function PositiveSemiDefiniteStructure(
         network_dim::Integer;
-        pos_def = (x, x0) -> log(1.0 + (x - x0) ⋅ (x - x0)),
+        pos_def = (x, x0) -> log(1 + (x - x0) ⋅ (x - x0)),
         non_neg = (net, x, x0) -> 1 + net(x) ⋅ net(x),
         grad_pos_def = nothing,
         grad_non_neg = nothing,

--- a/src/structure_specification.jl
+++ b/src/structure_specification.jl
@@ -11,7 +11,7 @@ Dynamics are assumed to be in `f(state, p, t)` form, as in an `ODEFunction`. For
 `f(state, input, p, t)`, consider using [`add_policy_search`](@ref).
 
 # Example
-```jldoctest; filter = r"(?m)^\\s*V̇\\(x\\)\\s*=\\s*(?=.*f\\(x,\\s*p,\\s*t\\))(?=.*∇φ\\(x\\))(?:\\s*(?:f\\(x,\\s*p,\\s*t\\)\\s*\\*\\s*∇φ\\(x\\)|∇φ\\(x\\)\\s*\\*\\s*f\\(x,\\s*p,\\s*t\\))\\s*)\$"
+```jldoctest; filter = [r"f\\(\\s*x,\\s*p,\\s*t\\s*\\)" => "ẋ", r"φ\\(x\\)" => "φ", r"(?m)\\s*V̇\\(x\\)\\s*=\\s*(∇φ\\s*\\*\\s*ẋ|ẋ\\s*\\*\\s*∇φ)\$"]
 julia> NoAdditionalStructure()
 NeuralLyapunovStructure
     Network dimension: 1
@@ -62,7 +62,7 @@ Dynamics are assumed to be in `f(state, p, t)` form, as in an `ODEFunction`. For
 `f(state, input, p, t)`, consider using [`add_policy_search`](@ref).
 
 # Example
-```jldoctest; filter = [r"(?m)\\s*V\\(x\\)\\s*=\\s*(0\\.1\\s*log\\(\\s*1\\s*\\+\\s*\\(x\\s*-\\s*x_0\\)²\\)|\\|\\|\\s*φ\\(x\\)\\s*\\|\\|²)\\s*(?:\\+\\s*(?:0\\.1\\s*log\\(\\s*1\\s*\\+\\s*\\(x\\s*-\\s*x_0\\)²\\)|\\|\\|\\s*φ\\(x\\)\\s*\\|\\|²))\$", r"(?m)\\s*V̇\\(x\\)\\s*=\\s*(?:2\\(φ\\(x\\)\\)\\s*⋅\\s*\\(f\\(x,\\s*p,\\s*t\\)\\s*\\*\\s*Jφ\\(x\\)\\)\\s*\\+\\s*\\(0\\.2\\(x\\s*-\\s*x_0\\)\\s*\\*\\s*f\\(x,\\s*p,\\s*t\\)\\)\\s*/\\s*\\(1\\s*\\+\\s*\\(x\\s*-\\s*x_0\\)²\\)|\\(0\\.2\\(x\\s*-\\s*x_0\\)\\s*\\*\\s*f\\(x,\\s*p,\\s*t\\)\\)\\s*/\\s*\\(1\\s*\\+\\s*\\(x\\s*-\\s*x_0\\)²\\)\\s*\\+\\s*2\\(φ\\(x\\)\\)\\s*⋅\\s*\\(f\\(x,\\s*p,\\s*t\\)\\s*\\*\\s*Jφ\\(x\\)\\))\$"]
+```jldoctest; filter = [r"\\(?x - x_0\\)?" => "Δ", r"f\\(\\s*x,\\s*p,\\s*t\\s*\\)" => "ẋ", r"\\s*\\*\\s*" => "", r"φ\\(x\\)|\\(φ\\(x\\)\\)" => "φ", r"\\|\\|φ\\|\\|²" => "φ²", r"0.1\\s*log\\((1\\s*\\+\\s*Δ²|Δ²\\s*\\+\\s*1)\\)" => "A", r"(?m)\\s*V\\(x\\)\\s*=\\s*(A\\s*\\+\\s*φ²|φ²\\s*\\+\\s*A)\$", r"2(φ⋅φ̇|φ̇⋅φ)" => "B", r"\\(?(1\\s*\\+\\s*Δ²|Δ²\\s*\\+\\s*1)\\)?"=> "C", r"\\(?0.2(Δẋ|ẋΔ)\\)?" => "D", r"D\\s*/\\s*C" => "E", r"(?m)\\s*V̇\\(x\\)\\s*=\\s*(B\\s*\\+\\s*E|E\\s*\\+\\s*B)\$"]
 julia> NonnegativeStructure(3; δ = 0.1)
 NeuralLyapunovStructure
     Network dimension: 3


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This PR primarliy updates doctests to use regex filters so they're more robust to changes in how Symbolics/ModelingToolkit orders commutative terms. It additionally tweaks `Base.show` for more consistent and readable printing.